### PR TITLE
add Google Vertex AI environment variables to the list of valid variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ pi-acp --terminal-login
 
 Your ACP client can also invoke this automatically based on the agent's advertised `authMethods`.
 
+### Google Vertex AI
+
+If you use Vertex AI as the inference provider, follow the instructions in the official [Pi documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md). This only provides access to Google's own Gemini models. If you need access to Anthropic and other providers' models install the `@ssweens/pi-vertex` extension using the pi-cli.
+
+```bash
+pi install npm:@ssweens/pi-vertex
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Your ACP client can also invoke this automatically based on the agent's advertis
 
 ### Google Vertex AI
 
-If you use Vertex AI as the inference provider, follow the instructions in the official [Pi documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md). This only provides access to Google's own Gemini models. If you need access to Anthropic and other providers' models install the `@ssweens/pi-vertex` extension using the pi-cli.
+If you use Vertex AI as the inference provider, follow the instructions in the official [Pi documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md). This only provides access to Google's own Gemini models. If you need access to Anthropic and other providers' models install the [@ssweens/pi-vertex](https://www.npmjs.com/package/@ssweens/pi-vertex) extension using the pi-cli.
 
 ```bash
 pi install npm:@ssweens/pi-vertex

--- a/src/pi-auth/status.ts
+++ b/src/pi-auth/status.ts
@@ -25,6 +25,15 @@ export function getPiAgentDir(): string {
   return join(homedir(), '.pi', 'agent')
 }
 
+function hasGoogleVertexAuth(): boolean {
+  const credentialsPath = process.env['GOOGLE_APPLICATION_CREDENTIALS']?.trim()
+  const defaultCredentialsPath = join(homedir(), '.config', 'gcloud', 'application_default_credentials.json')
+  const hasCredentials = (credentialsPath && existsSync(credentialsPath)) || existsSync(defaultCredentialsPath)
+  const hasProject = !!(process.env['GOOGLE_CLOUD_PROJECT']?.trim() || process.env['GCLOUD_PROJECT']?.trim())
+  const hasLocation = !!process.env['GOOGLE_CLOUD_LOCATION']?.trim()
+  return !!(hasCredentials && hasProject && hasLocation)
+}
+
 export function hasAnyPiAuthConfigured(): boolean {
   // 1) auth.json present and non-empty (api keys or oauth creds)
   const agentDir = getPiAgentDir()
@@ -69,17 +78,16 @@ export function hasAnyPiAuthConfigured(): boolean {
     'GITHUB_TOKEN',
     // Anthropic oauth
     'ANTHROPIC_OAUTH_TOKEN',
-    'ANTHROPIC_API_KEY',
-    // Google Vertex AI support using `gloud auth application-default login` or a credentials file
-    'GOOGLE_APPLICATION_CREDENTIALS',
-    'GOOGLE_CLOUD_PROJECT',
-    'GOOGLE_CLOUD_LOCATION'
+    'ANTHROPIC_API_KEY'
   ]
 
   for (const k of envVars) {
     const v = process.env[k]
     if (typeof v === 'string' && v.trim()) return true
   }
+
+  // 4) Google Vertex AI auth (credentials + project + location)
+  if (hasGoogleVertexAuth()) return true
 
   return false
 }

--- a/src/pi-auth/status.ts
+++ b/src/pi-auth/status.ts
@@ -69,7 +69,11 @@ export function hasAnyPiAuthConfigured(): boolean {
     'GITHUB_TOKEN',
     // Anthropic oauth
     'ANTHROPIC_OAUTH_TOKEN',
-    'ANTHROPIC_API_KEY'
+    'ANTHROPIC_API_KEY',
+    // Google Vertex AI support using `gloud auth application-default login` or a credentials file
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'GOOGLE_CLOUD_PROJECT',
+    'GOOGLE_CLOUD_LOCATION'
   ]
 
   for (const k of envVars) {


### PR DESCRIPTION
Hi!

I was having issues getting the pi-acp to run in Zed due to using Vertex as the inference provider, so I poked around and found the fix to be rather easy and figured I should contribute it back to the project, since I'm probably not the only one using Vertex. 🙂 

### Changes
- Added Vertex required environment variables to the list of valid vars
- Updated the README with instructions pointing to the setup process
  - Vertex support is built-in to Pi, but the default agent only provides access to Gemini models, so I also added a note to install the `pi-vertex` extension

Thanks for the wonderful project!