### PR TITLE
feat: map bash tool kind to 'execute' for expanded output in Zed

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -679,10 +679,12 @@ function toToolKind(toolName: string): ToolKind {
     case 'edit':
       return 'edit'
     case 'bash':
-      // Many ACP clients render `execute` tool calls only via the terminal APIs.
-      // Since this adapter lets pi execute locally (no client terminal delegation),
-      // we report bash as `other` so clients show inline text output blocks.
-      return 'other'
+      // Report bash as `execute` so ACP clients (e.g. Zed) render it as a
+      // terminal card that is expanded by default (controlled by the client's
+      // `expand_terminal_card` setting).  pi executes commands locally — no
+      // client terminal delegation is used — but Zed still renders the text
+      // content blocks correctly inside an execute-kind card.
+      return 'execute'
     default:
       return 'other'
   }


### PR DESCRIPTION
## Problem

Bash tool calls are reported as `kind: "other"`, which causes Zed to render them as generic tool call cards that are **collapsed by default**. Users have to manually click each bash output to see it.

## Solution

Change the `toToolKind()` mapping for `bash` from `'other'` to `'execute'`. This makes Zed treat bash output as a terminal card, which is **expanded by default** (controlled by the client's `expand_terminal_card` setting, default `true`).

pi executes commands locally — no ACP terminal delegation is used — but Zed still renders the text content blocks correctly inside an execute-kind card.

## Validation

- `npm run build` — passes
- `npm test` — 65/66 pass (1 pre-existing auth test failure unrelated to this change)