### PR TITLE
feat(acp): improve Zed integration (usage telemetry, structured diffs, session metadata, /version)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.26",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.12.0",
+        "@agentclientprotocol/sdk": "^0.19.1",
         "zod": "^3.25.0"
       },
       "bin": {
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.12.0.tgz",
-      "integrity": "sha512-V8uH/KK1t7utqyJmTA7y7DzKu6+jKFIXM+ZVouz8E55j8Ej2RV42rEvPKn3/PpBJlliI5crcGk1qQhZ7VwaepA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.19.1.tgz",
+      "integrity": "sha512-oSb3RzjlMoU3Xu6MRJAL/Gd1DyK2+XSmZyUENrt/j1yqt33+ROhxncU6em8nyXEs97D4lVIGaFZ1pN0Q1C9SpA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.12.0",
+    "@agentclientprotocol/sdk": "^0.19.1",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -28,7 +28,7 @@ import { normalizePiAssistantText, normalizePiMessageText } from './translate/pi
 import { toolResultToText } from './translate/pi-tools.js'
 import { promptToPiMessage } from './translate/prompt.js'
 import { loadSlashCommands, parseCommandArgs, toAvailableCommands } from './slash-commands.js'
-import { getAgentDir, getEnableSkillCommands, getQuietStartup } from './pi-settings.js'
+import { getAgentDir, getEnableExtensionCommands, getEnableSkillCommands, getQuietStartup } from './pi-settings.js'
 import { toAvailableCommandsFromPiGetCommands } from './pi-commands.js'
 import { isAbsolute } from 'node:path'
 import { existsSync, readFileSync, realpathSync, readdirSync, statSync } from 'node:fs'
@@ -198,6 +198,7 @@ export class PiAcpAgent implements ACPAgent {
 
     const fileCommands = loadSlashCommands(params.cwd)
     const enableSkillCommands = getEnableSkillCommands(params.cwd)
+    const enableExtensionCommands = getEnableExtensionCommands(params.cwd)
 
     // Pi doesn't support mcpServers, but we accept and store.
     const session = await this.sessions.create({
@@ -343,7 +344,7 @@ export class PiAcpAgent implements ACPAgent {
           const pi = (await session.proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
             enableSkillCommands,
-            includeExtensionCommands: false
+            includeExtensionCommands: enableExtensionCommands
           })
 
           await this.conn.sessionUpdate({
@@ -932,6 +933,7 @@ export class PiAcpAgent implements ACPAgent {
 
     const fileCommands = loadSlashCommands(params.cwd)
     const enableSkillCommands = getEnableSkillCommands(params.cwd)
+    const enableExtensionCommands = getEnableExtensionCommands(params.cwd)
 
     const session = this.sessions.getOrCreate(params.sessionId, {
       cwd: params.cwd,
@@ -1081,7 +1083,7 @@ export class PiAcpAgent implements ACPAgent {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
             enableSkillCommands,
-            includeExtensionCommands: false
+            includeExtensionCommands: enableExtensionCommands
           })
 
           await this.conn.sessionUpdate({

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -122,15 +122,33 @@ export class PiAcpAgent implements ACPAgent {
   // Remember recent session cwd and use it as the default filter.
   private lastSessionCwd: string | null = null
 
+  /**
+   * Whether the connected ACP client renders `usage_update` natively (context ring / cost chip)
+   * and therefore does NOT need the inline text-status fallback. Decided during `initialize`
+   * from `clientInfo.name`. Defaults to `false` so unknown clients still get the text line.
+   */
+  private clientRendersUsageNatively = false
+
   constructor(conn: AgentSideConnection, _config?: unknown) {
     this.conn = conn
     void _config
   }
 
+  /**
+   * ACP doesn't (yet) expose a `usage_update` capability flag in `ClientCapabilities`, so we use
+   * `clientInfo.name` as a proxy. Keep this list conservative — false negatives just mean the
+   * text status line is shown (harmless), but false positives would hide the info entirely.
+   */
+  private static readonly NATIVE_USAGE_CLIENTS: ReadonlySet<string> = new Set(['zed'])
+
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
     // We currently only support ACP protocol version 1.
     const supportedVersion = 1
     const requested = params.protocolVersion
+
+    const clientName = (params as any)?.clientInfo?.name
+    this.clientRendersUsageNatively =
+      typeof clientName === 'string' && PiAcpAgent.NATIVE_USAGE_CLIENTS.has(clientName.toLowerCase())
 
     return {
       protocolVersion: requested === supportedVersion ? requested : supportedVersion,
@@ -187,7 +205,8 @@ export class PiAcpAgent implements ACPAgent {
       mcpServers: params.mcpServers,
       conn: this.conn,
       fileCommands,
-      piCommand: process.env.PI_ACP_PI_COMMAND
+      piCommand: process.env.PI_ACP_PI_COMMAND,
+      clientRendersUsageNatively: this.clientRendersUsageNatively
     })
 
     // NOTE: we re-fetch state + models below; the session was constructed without
@@ -919,7 +938,8 @@ export class PiAcpAgent implements ACPAgent {
       mcpServers: params.mcpServers,
       conn: this.conn,
       proc,
-      fileCommands
+      fileCommands,
+      clientRendersUsageNatively: this.clientRendersUsageNatively
     })
 
     // Policy: within a single ACP connection (one Zed window), keep only one live pi subprocess.

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -36,8 +36,16 @@ import type { AvailableCommand } from '@agentclientprotocol/sdk'
 import { join, dirname, basename } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { hasAnyPiAuthConfigured } from '../pi-auth/status.js'
+import { formatVersionBlock, formatVersionLabel, getAgentInfoVersion, getVersionInfo } from '../version.js'
 
 type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+
+function shortSessionTitle(sessionId: string): string {
+  // pi sessionIds are ULID-ish; show the first 8 chars as a stable placeholder.
+  // Prefixed with the pi-acp build identifier so users can tell at a glance
+  // which adapter build they're talking to (useful for local iteration).
+  return `${formatVersionLabel()} · pi-${sessionId.slice(0, 8)}`
+}
 
 function builtinAvailableCommands(): AvailableCommand[] {
   return [
@@ -77,6 +85,10 @@ function builtinAvailableCommands(): AvailableCommand[] {
     {
       name: 'changelog',
       description: 'Show pi changelog'
+    },
+    {
+      name: 'version',
+      description: 'Show pi-acp version, git sha, and build time'
     }
   ]
 }
@@ -125,7 +137,7 @@ export class PiAcpAgent implements ACPAgent {
       agentInfo: {
         name: pkg.name ?? 'pi-acp',
         title: 'pi ACP adapter',
-        version: pkg.version ?? '0.0.0'
+        version: getAgentInfoVersion()
       },
       // Zed currently uses ClientCapabilities._meta["terminal-auth"] to decide whether to show
       // the "Authenticate" banner/button. If not supported, we still return the method for the registry.
@@ -178,6 +190,9 @@ export class PiAcpAgent implements ACPAgent {
       piCommand: process.env.PI_ACP_PI_COMMAND
     })
 
+    // NOTE: we re-fetch state + models below; the session was constructed without
+    // the current modelId/contextWindow and we'll set them once we know them.
+
     // Fetch state + models once (parallel) to reduce startup latency.
     let state: any = null
     let availableModels: any = null
@@ -219,6 +234,12 @@ export class PiAcpAgent implements ACPAgent {
     const models = await getModelState(session.proc, { state, availableModels })
     const thinking = await getThinkingState(session.proc, { state })
 
+    // Seed the session with context-window + current model so the usage status line
+    // can compute a context-fill %.
+    const modelContextWindow =
+      typeof (state as any)?.model?.contextWindow === 'number' ? (state as any).model.contextWindow : null
+    session.setCurrentModel(models?.currentModelId ?? null, modelContextWindow)
+
     const quietStartup = getQuietStartup(params.cwd)
     const updateNotice = buildUpdateNotice()
 
@@ -259,11 +280,46 @@ export class PiAcpAgent implements ACPAgent {
     // it will still be emitted as the first chunk of the first prompt.
     if (preludeText) setTimeout(() => session.sendStartupInfoIfPending(), 0)
 
-    // Advertise slash commands (ACP: available_commands_update)
+    // Post-response bootstrap: session metadata (title + mode + _meta) then slash commands.
     // Important: some clients (e.g. Zed) will ignore notifications for an unknown sessionId.
-    // So we must send this *after* the session/new response has been delivered.
+    // So we must send these *after* the session/new response has been delivered.
     setTimeout(() => {
       void (async () => {
+        try {
+          const initialTitle = typeof (state as any)?.sessionName === 'string' && (state as any).sessionName.trim()
+            ? (state as any).sessionName.trim()
+            : shortSessionTitle(session.sessionId)
+
+          await this.conn.sessionUpdate({
+            sessionId: session.sessionId,
+            update: {
+              sessionUpdate: 'session_info_update',
+              title: initialTitle,
+              updatedAt: new Date().toISOString(),
+              _meta: {
+                piAcp: {
+                  version: getVersionInfo(),
+                  model: models?.currentModelId ?? null,
+                  contextWindow: modelContextWindow,
+                  sessionFile: typeof (state as any)?.sessionFile === 'string' ? (state as any).sessionFile : null
+                }
+              }
+            }
+          })
+
+          if (thinking?.currentModeId) {
+            await this.conn.sessionUpdate({
+              sessionId: session.sessionId,
+              update: {
+                sessionUpdate: 'current_mode_update',
+                currentModeId: thinking.currentModeId
+              }
+            })
+          }
+        } catch {
+          // best-effort only
+        }
+
         try {
           const pi = (await session.proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -522,6 +578,17 @@ export class PiAcpAgent implements ACPAgent {
         return { stopReason: 'end_turn' }
       }
 
+      if (cmd === 'version') {
+        await this.conn.sessionUpdate({
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: '```\n' + formatVersionBlock() + '\n```' }
+          }
+        })
+        return { stopReason: 'end_turn' }
+      }
+
       if (cmd === 'changelog') {
         // Read pi's installed CHANGELOG.md. Adapter-side, no model call.
         const findChangelog = (): string | null => {
@@ -756,7 +823,22 @@ export class PiAcpAgent implements ACPAgent {
     const stopReason: StopReason =
       result === 'error' ? (session.wasCancelRequested() ? 'cancelled' : 'end_turn') : result
 
-    return { stopReason }
+    // Attach cumulative session usage (ACP ≥0.14) so clients that support the
+    // experimental `Usage` field on PromptResponse can render per-message token splits.
+    const usage = session.getCumulativeUsage()
+    return {
+      stopReason,
+      usage:
+        usage.totalTokens > 0
+          ? {
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              totalTokens: usage.totalTokens,
+              cachedReadTokens: usage.cachedReadTokens,
+              cachedWriteTokens: usage.cachedWriteTokens
+            }
+          : undefined
+    }
   }
 
   async cancel(params: CancelNotification): Promise<void> {
@@ -917,8 +999,13 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    const models = await getModelState(proc)
-    const thinking = await getThinkingState(proc)
+    const loadState = (await proc.getState().catch(() => null)) as any
+    const models = await getModelState(proc, { state: loadState })
+    const thinking = await getThinkingState(proc, { state: loadState })
+
+    const loadedContextWindow =
+      typeof loadState?.model?.contextWindow === 'number' ? loadState.model.contextWindow : null
+    session.setCurrentModel(models?.currentModelId ?? null, loadedContextWindow)
 
     const response = {
       models,
@@ -930,9 +1017,46 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    // Advertise slash commands after the response so the client knows the session exists.
+    // Post-response bootstrap: slash commands + session metadata. All are scheduled
+    // together so tests can assert a single timer deferral and clients see them
+    // in a predictable order after the session/load response lands.
     setTimeout(() => {
       void (async () => {
+        try {
+          const title = typeof loadState?.sessionName === 'string' && loadState.sessionName.trim()
+            ? loadState.sessionName.trim()
+            : shortSessionTitle(session.sessionId)
+
+          await this.conn.sessionUpdate({
+            sessionId: session.sessionId,
+            update: {
+              sessionUpdate: 'session_info_update',
+              title,
+              updatedAt: new Date().toISOString(),
+              _meta: {
+                piAcp: {
+                  version: getVersionInfo(),
+                  model: models?.currentModelId ?? null,
+                  contextWindow: loadedContextWindow,
+                  sessionFile: typeof loadState?.sessionFile === 'string' ? loadState.sessionFile : sessionFile
+                }
+              }
+            }
+          })
+
+          if (thinking?.currentModeId) {
+            await this.conn.sessionUpdate({
+              sessionId: session.sessionId,
+              update: {
+                sessionUpdate: 'current_mode_update',
+                currentModeId: thinking.currentModeId
+              }
+            })
+          }
+        } catch {
+          // best-effort
+        }
+
         try {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -997,6 +1121,15 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     await session.proc.setModel(provider, modelId)
+
+    // Refresh our cached context window + model id so the usage line stays accurate.
+    try {
+      const fresh = (await session.proc.getState()) as any
+      const cw = typeof fresh?.model?.contextWindow === 'number' ? fresh.model.contextWindow : null
+      session.setCurrentModel(`${provider}/${modelId}`, cw)
+    } catch {
+      session.setCurrentModel(`${provider}/${modelId}`, null)
+    }
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1193,21 +1326,24 @@ function buildStartupInfo(opts: {
 
   const md: string[] = []
 
-  // pi version header
+  // pi-acp + pi header. Users running a local build get the git sha and a
+  // (dev) marker here so they can distinguish their working tree from the
+  // npm-published build.
+  md.push(formatVersionLabel())
+
   try {
     const piVersion = spawnSync('pi', ['--version'], { encoding: 'utf-8' })
     const installed = (String(piVersion.stdout ?? '').trim() || String(piVersion.stderr ?? '').trim()).replace(
       /^v/i,
       ''
     )
-    if (installed) {
-      md.push(`pi v${installed}`)
-      md.push('---')
-      md.push('')
-    }
+    if (installed) md.push(`pi v${installed}`)
   } catch {
     // ignore
   }
+
+  md.push('---')
+  md.push('')
 
   const addSection = (title: string, items: string[]) => {
     const cleaned = items.map(s => s.trim()).filter(Boolean)

--- a/src/acp/pi-settings.ts
+++ b/src/acp/pi-settings.ts
@@ -58,6 +58,29 @@ export function getEnableSkillCommands(cwd: string): boolean {
 }
 
 /**
+ * Mirror pi settings semantics for extension-sourced slash commands (e.g. /worktree,
+ * /plannotator, /mcp, /jarvis …).
+ *
+ * Resolution order (first wins):
+ *   1. `PI_ACP_ENABLE_EXTENSION_COMMANDS` env var (`true` | `false`)
+ *   2. `enableExtensionCommands` in merged pi settings (global + project)
+ *   3. Default: `true` — matches the behavior of skill commands, so extension-provided
+ *      commands are discoverable in ACP clients by default. Set to `false` to hide them
+ *      (useful if an extension emits UI requests the ACP adapter doesn't handle).
+ */
+export function getEnableExtensionCommands(cwd: string): boolean {
+  const env = process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS
+  if (env === 'true') return true
+  if (env === 'false') return false
+
+  const merged = getMergedSettings(cwd)
+  const direct = merged.enableExtensionCommands
+  if (typeof direct === 'boolean') return direct
+
+  return true
+}
+
+/**
  * Mirror pi's quietStartup setting: if true, pi suppresses the verbose startup prelude.
  * We use it to decide whether to synthesize + emit our own "startup info" message.
  */

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -34,6 +34,13 @@ type SessionCreateParams = {
   contextWindow?: number | null
   /** Initial model id (provider/model), used for the status line. */
   modelId?: string | null
+  /**
+   * Whether the ACP client is known to render `usage_update` natively (e.g. as a context ring
+   * and/or cost chip). When `true`, the inline `agent_message_chunk` status-line fallback is
+   * suppressed to avoid duplicating information already shown in the client UI. Decided by the
+   * agent at `initialize` time from `clientInfo.name`.
+   */
+  clientRendersUsageNatively?: boolean
 }
 
 export type StopReason = 'end_turn' | 'cancelled' | 'error'
@@ -171,7 +178,8 @@ export class SessionManager {
       conn: params.conn,
       fileCommands: params.fileCommands ?? [],
       contextWindow: params.contextWindow ?? null,
-      modelId: params.modelId ?? null
+      modelId: params.modelId ?? null,
+      clientRendersUsageNatively: params.clientRendersUsageNatively ?? false
     })
 
     this.sessions.set(sessionId, session)
@@ -200,7 +208,8 @@ export class SessionManager {
       conn: params.conn,
       fileCommands: params.fileCommands ?? [],
       contextWindow: params.contextWindow ?? null,
-      modelId: params.modelId ?? null
+      modelId: params.modelId ?? null,
+      clientRendersUsageNatively: params.clientRendersUsageNatively ?? false
     })
 
     this.sessions.set(sessionId, session)
@@ -259,6 +268,7 @@ export class PiAcpSession {
   private lastAssistantUsage: PiUsage | null = null
   private currentModelId: string | null
   private contextWindow: number | null
+  private readonly clientRendersUsageNatively: boolean
 
   constructor(opts: {
     sessionId: string
@@ -269,6 +279,7 @@ export class PiAcpSession {
     fileCommands?: FileSlashCommand[]
     contextWindow?: number | null
     modelId?: string | null
+    clientRendersUsageNatively?: boolean
   }) {
     this.sessionId = opts.sessionId
     this.cwd = opts.cwd
@@ -278,6 +289,7 @@ export class PiAcpSession {
     this.fileCommands = opts.fileCommands ?? []
     this.contextWindow = opts.contextWindow ?? null
     this.currentModelId = opts.modelId ?? null
+    this.clientRendersUsageNatively = opts.clientRendersUsageNatively ?? false
 
     this.proc.onEvent(ev => this.handlePiEvent(ev))
   }
@@ -297,6 +309,23 @@ export class PiAcpSession {
       cachedReadTokens: this.sessionUsage.cacheRead,
       cachedWriteTokens: this.sessionUsage.cacheWrite
     }
+  }
+
+  /**
+   * Decide whether to emit the inline status-line `agent_message_chunk` fallback.
+   *
+   * Order of precedence:
+   *   1. `PI_ACP_USAGE_STATUS=never`     → false
+   *   2. `PI_ACP_HIDE_USAGE_STATUS=1`    → false (legacy alias)
+   *   3. `PI_ACP_USAGE_STATUS=always`    → true
+   *   4. `PI_ACP_USAGE_STATUS=auto` (or unset) → !clientRendersUsageNatively
+   */
+  private shouldEmitUsageStatusText(): boolean {
+    const mode = (process.env.PI_ACP_USAGE_STATUS ?? '').toLowerCase()
+    if (mode === 'never') return false
+    if (process.env.PI_ACP_HIDE_USAGE_STATUS === '1') return false
+    if (mode === 'always') return true
+    return !this.clientRendersUsageNatively
   }
 
   private snapshotUsage(): UsageSnapshot {
@@ -755,8 +784,12 @@ export class PiAcpSession {
         //      model's contextWindow.
         //   2. `session_info_update` with `_meta.piAcp.usage` — structured data other
         //      clients / tools can read even without the beta flag.
-        //   3. An inline `agent_message_chunk` status line — visible in any client. Can
-        //      be suppressed by `PI_ACP_HIDE_USAGE_STATUS=1`.
+        //   3. An inline `agent_message_chunk` status line — visible in any client that only
+        //      renders text. Suppressed automatically when the ACP client is known to render
+        //      `usage_update` natively (e.g. Zed's context ring) to avoid duplicate display.
+        //      Precedence for the gating decision:
+        //        PI_ACP_USAGE_STATUS = 'never' | 'always' | 'auto' (default)
+        //        legacy: PI_ACP_HIDE_USAGE_STATUS=1 → equivalent to 'never'
         const snap = this.snapshotUsage()
         const lastPromptTokens = this.lastAssistantUsage
           ? this.lastAssistantUsage.input +
@@ -789,7 +822,7 @@ export class PiAcpSession {
           }
         })
 
-        if (process.env.PI_ACP_HIDE_USAGE_STATUS !== '1' && snap.sessionTotalTokens > 0) {
+        if (this.shouldEmitUsageStatusText() && snap.sessionTotalTokens > 0) {
           const text = formatUsageStatus(snap, { includeSessionTotal: true })
           if (text) {
             this.emit({

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -15,6 +15,14 @@ import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent } from '../pi-rpc/proces
 import { SessionStore } from './session-store.js'
 import { toolResultToText } from './translate/pi-tools.js'
 import { expandSlashCommand, type FileSlashCommand } from './slash-commands.js'
+import {
+  addUsage,
+  emptyUsage,
+  formatUsageStatus,
+  parsePiUsage,
+  type PiUsage,
+  type UsageSnapshot
+} from './translate/usage.js'
 
 type SessionCreateParams = {
   cwd: string
@@ -22,6 +30,10 @@ type SessionCreateParams = {
   conn: AgentSideConnection
   fileCommands?: import('./slash-commands.js').FileSlashCommand[]
   piCommand?: string
+  /** Initial model context window, used to compute the context-fill %. */
+  contextWindow?: number | null
+  /** Initial model id (provider/model), used for the status line. */
+  modelId?: string | null
 }
 
 export type StopReason = 'end_turn' | 'cancelled' | 'error'
@@ -60,6 +72,28 @@ function toToolCallLocations(args: unknown, cwd: string, line?: number): ToolCal
 
   const resolvedPath = isAbsolute(path) ? path : resolvePath(cwd, path)
   return [{ path: resolvedPath, ...(typeof line === 'number' ? { line } : {}) }]
+}
+
+// Tools whose stdout we want the client to render in a fixed-width block. Pi's
+// `bash` tool emits raw shell output that otherwise gets re-flowed by the
+// markdown renderer in Zed / other clients.
+const FENCED_OUTPUT_TOOLS = new Set(['bash'])
+
+function fenceBashOutput(text: string): string {
+  if (!text) return text
+  // Use the longest run of backticks in `text` + 1 as the fence length so we
+  // never terminate early on output that itself contains ``` sequences.
+  const longestRun = (text.match(/`+/g) ?? []).reduce((n, s) => Math.max(n, s.length), 0)
+  const fence = '`'.repeat(Math.max(3, longestRun + 1))
+  return `${fence}shell\n${text.replace(/\n$/, '')}\n${fence}`
+}
+
+function formatToolOutputContent(toolName: string, text: string): ToolCallContent[] | undefined {
+  if (!text) return undefined
+  if (FENCED_OUTPUT_TOOLS.has(toolName)) {
+    return [{ type: 'content', content: { type: 'text', text: fenceBashOutput(text) } }]
+  }
+  return [{ type: 'content', content: { type: 'text', text } }]
 }
 
 export class SessionManager {
@@ -135,7 +169,9 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      contextWindow: params.contextWindow ?? null,
+      modelId: params.modelId ?? null
     })
 
     this.sessions.set(sessionId, session)
@@ -162,7 +198,9 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc: params.proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      contextWindow: params.contextWindow ?? null,
+      modelId: params.modelId ?? null
     })
 
     this.sessions.set(sessionId, session)
@@ -192,20 +230,35 @@ export class PiAcpSession {
   // Track tool call statuses and ensure they are monotonic (pending -> in_progress -> completed).
   // Some pi events can arrive out of order (e.g. late toolcall_* deltas after execution starts),
   // and clients may hide progress if we ever downgrade back to `pending`.
-  private currentToolCalls = new Map<string, 'pending' | 'in_progress'>()
+  //
+  // Keeps `toolName` alongside the status so subsequent `tool_execution_update`
+  // / `tool_execution_end` events (which only carry the toolCallId) can still
+  // drive per-tool output formatting (e.g. fenced bash output, structured
+  // diffs).
+  private currentToolCalls = new Map<string, { status: 'pending' | 'in_progress'; toolName: string }>()
 
   // pi can emit multiple `turn_end` events for a single user prompt (e.g. after tool_use).
   // The overall agent loop completes when `agent_end` is emitted.
   private inAgentLoop = false
 
-  // For ACP diff support: capture file contents before edits, then emit ToolCallContent {type:"diff"}.
-  // This is due to pi sending diff as a string as opposed to ACP expected diff format.
-  // Compatible format may need to be implemented in pi in the future.
-  private editSnapshots = new Map<string, { path: string; oldText: string }>()
+  // For ACP diff support: capture file contents before `edit` / `write`, then
+  // emit ToolCallContent {type:"diff"} on completion. This is done because pi
+  // sends its diff as a pre-formatted string rather than the structured shape
+  // ACP expects. A compatible native format may land in pi in the future.
+  //
+  // For `write` against a new file we record oldText = '' so the client can
+  // still render the creation as a diff against an empty file.
+  private fileSnapshots = new Map<string, { path: string; oldText: string; toolName: 'edit' | 'write' }>()
 
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
   private lastEmit: Promise<void> = Promise.resolve()
+
+  // Usage telemetry. Populated from pi `message_end` events on assistant messages.
+  private sessionUsage: PiUsage = emptyUsage()
+  private lastAssistantUsage: PiUsage | null = null
+  private currentModelId: string | null
+  private contextWindow: number | null
 
   constructor(opts: {
     sessionId: string
@@ -214,6 +267,8 @@ export class PiAcpSession {
     proc: PiRpcProcess
     conn: AgentSideConnection
     fileCommands?: FileSlashCommand[]
+    contextWindow?: number | null
+    modelId?: string | null
   }) {
     this.sessionId = opts.sessionId
     this.cwd = opts.cwd
@@ -221,8 +276,49 @@ export class PiAcpSession {
     this.proc = opts.proc
     this.conn = opts.conn
     this.fileCommands = opts.fileCommands ?? []
+    this.contextWindow = opts.contextWindow ?? null
+    this.currentModelId = opts.modelId ?? null
 
     this.proc.onEvent(ev => this.handlePiEvent(ev))
+  }
+
+  /** Called by the agent layer when a client sets a new model via `unstable_setSessionModel`. */
+  setCurrentModel(modelId: string | null, contextWindow: number | null): void {
+    this.currentModelId = modelId
+    if (contextWindow !== null) this.contextWindow = contextWindow
+  }
+
+  /** Snapshot of cumulative session usage, for attaching to a PromptResponse. */
+  getCumulativeUsage() {
+    return {
+      inputTokens: this.sessionUsage.input,
+      outputTokens: this.sessionUsage.output,
+      totalTokens: this.sessionUsage.totalTokens,
+      cachedReadTokens: this.sessionUsage.cacheRead,
+      cachedWriteTokens: this.sessionUsage.cacheWrite
+    }
+  }
+
+  private snapshotUsage(): UsageSnapshot {
+    const last = this.lastAssistantUsage
+    const lastPromptTokens = last ? last.input + last.cacheRead + last.cacheWrite : 0
+    const fill =
+      last && this.contextWindow && this.contextWindow > 0
+        ? Math.min(1, lastPromptTokens / this.contextWindow)
+        : null
+
+    return {
+      lastTurnTokens: last?.totalTokens ?? 0,
+      lastTurnCost: last?.cost.total ?? 0,
+      sessionInputTokens: this.sessionUsage.input,
+      sessionOutputTokens: this.sessionUsage.output,
+      sessionCacheReadTokens: this.sessionUsage.cacheRead,
+      sessionCacheWriteTokens: this.sessionUsage.cacheWrite,
+      sessionTotalTokens: this.sessionUsage.totalTokens,
+      sessionCost: this.sessionUsage.cost.total,
+      contextWindow: this.contextWindow,
+      contextFillRatio: fill
+    }
   }
 
   setStartupInfo(text: string) {
@@ -421,12 +517,12 @@ export class PiAcpSession {
                   })()
 
             const locations = toToolCallLocations(rawInput, this.cwd)
-            const existingStatus = this.currentToolCalls.get(toolCallId)
+            const existing = this.currentToolCalls.get(toolCallId)
             // IMPORTANT: never downgrade status (e.g. if we already marked in_progress via tool_execution_start).
-            const status = existingStatus ?? 'pending'
+            const status = existing?.status ?? 'pending'
 
-            if (!existingStatus) {
-              this.currentToolCalls.set(toolCallId, 'pending')
+            if (!existing) {
+              this.currentToolCalls.set(toolCallId, { status: 'pending', toolName })
               this.emit({
                 sessionUpdate: 'tool_call',
                 toolCallId,
@@ -463,18 +559,28 @@ export class PiAcpSession {
         let line: number | undefined
 
         // Capture pre-edit file contents so we can emit a structured ACP diff on completion.
-        if (toolName === 'edit') {
+        // `edit`: snapshot must already exist. `write`: new file is allowed, oldText = ''.
+        if (toolName === 'edit' || toolName === 'write') {
           const p = typeof args?.path === 'string' ? args.path : undefined
           if (p) {
+            const abs = isAbsolute(p) ? p : resolvePath(this.cwd, p)
+            let oldText: string | null = null
             try {
-              const abs = isAbsolute(p) ? p : resolvePath(this.cwd, p)
-              const oldText = readFileSync(abs, 'utf8')
-              this.editSnapshots.set(toolCallId, { path: p, oldText })
-
-              const needle = typeof args?.oldText === 'string' ? args.oldText : ''
-              line = findUniqueLineNumber(oldText, needle)
+              oldText = readFileSync(abs, 'utf8')
             } catch {
-              // Ignore snapshot failures; we'll fall back to plain text output.
+              // For `write`, treat a missing file as an empty pre-state so the client
+              // still renders the creation as a diff. For `edit`, we skip diffing
+              // if we can't snapshot.
+              if (toolName === 'write') oldText = ''
+            }
+
+            if (oldText !== null) {
+              this.fileSnapshots.set(toolCallId, { path: p, oldText, toolName })
+
+              if (toolName === 'edit') {
+                const needle = typeof args?.oldText === 'string' ? args.oldText : ''
+                line = findUniqueLineNumber(oldText, needle)
+              }
             }
           }
         }
@@ -483,7 +589,7 @@ export class PiAcpSession {
 
         // If we already surfaced the tool call while the model streamed it, just transition.
         if (!this.currentToolCalls.has(toolCallId)) {
-          this.currentToolCalls.set(toolCallId, 'in_progress')
+          this.currentToolCalls.set(toolCallId, { status: 'in_progress', toolName })
           this.emit({
             sessionUpdate: 'tool_call',
             toolCallId,
@@ -494,7 +600,7 @@ export class PiAcpSession {
             rawInput: args
           })
         } else {
-          this.currentToolCalls.set(toolCallId, 'in_progress')
+          this.currentToolCalls.set(toolCallId, { status: 'in_progress', toolName })
           this.emit({
             sessionUpdate: 'tool_call_update',
             toolCallId,
@@ -513,14 +619,13 @@ export class PiAcpSession {
 
         const partial = (ev as any).partialResult
         const text = toolResultToText(partial)
+        const toolName = this.currentToolCalls.get(toolCallId)?.toolName ?? ''
 
         this.emit({
           sessionUpdate: 'tool_call_update',
           toolCallId,
           status: 'in_progress',
-          content: text
-            ? ([{ type: 'content', content: { type: 'text', text } }] satisfies ToolCallContent[])
-            : undefined,
+          content: formatToolOutputContent(toolName, text),
           rawOutput: partial
         })
         break
@@ -533,10 +638,11 @@ export class PiAcpSession {
         const result = (ev as any).result
         const isError = Boolean((ev as any).isError)
         const text = toolResultToText(result)
+        const toolName = this.currentToolCalls.get(toolCallId)?.toolName ?? ''
 
-        // If this was an edit and we captured a snapshot, emit a structured ACP diff.
+        // If this was an edit/write and we captured a snapshot, emit a structured ACP diff.
         // This enables clients like Zed to render an actual diff UI.
-        const snapshot = this.editSnapshots.get(toolCallId)
+        const snapshot = this.fileSnapshots.get(toolCallId)
         let content: ToolCallContent[] | undefined
 
         if (!isError && snapshot) {
@@ -544,6 +650,7 @@ export class PiAcpSession {
             const abs = isAbsolute(snapshot.path) ? snapshot.path : resolvePath(this.cwd, snapshot.path)
             const newText = readFileSync(abs, 'utf8')
             if (newText !== snapshot.oldText) {
+              const followupText = formatToolOutputContent(toolName, text) ?? []
               content = [
                 {
                   type: 'diff',
@@ -551,7 +658,7 @@ export class PiAcpSession {
                   oldText: snapshot.oldText,
                   newText
                 },
-                ...(text ? ([{ type: 'content', content: { type: 'text', text } }] as ToolCallContent[]) : [])
+                ...followupText
               ]
             }
           } catch {
@@ -559,9 +666,9 @@ export class PiAcpSession {
           }
         }
 
-        // Fallback: just text content.
-        if (!content && text) {
-          content = [{ type: 'content', content: { type: 'text', text } }] satisfies ToolCallContent[]
+        // Fallback: just text content (fenced for bash so clients render a code block).
+        if (!content) {
+          content = formatToolOutputContent(toolName, text)
         }
 
         this.emit({
@@ -573,7 +680,7 @@ export class PiAcpSession {
         })
 
         this.currentToolCalls.delete(toolCallId)
-        this.editSnapshots.delete(toolCallId)
+        this.fileSnapshots.delete(toolCallId)
         break
       }
 
@@ -617,6 +724,21 @@ export class PiAcpSession {
         break
       }
 
+      case 'message_end': {
+        // Pi emits message_end for every role (user, assistant, toolResult).
+        // Only assistant messages carry `usage`. Each agent loop may emit several
+        // of these (one per model call), so we accumulate.
+        const message = (ev as any).message
+        if (message?.role === 'assistant') {
+          const usage = parsePiUsage(message.usage)
+          if (usage) {
+            this.lastAssistantUsage = usage
+            this.sessionUsage = addUsage(this.sessionUsage, usage)
+          }
+        }
+        break
+      }
+
       case 'turn_end': {
         // pi uses `turn_end` for sub-steps (e.g. tool_use) and will often start another turn.
         // Do NOT resolve the ACP `session/prompt` here; wait for `agent_end`.
@@ -624,6 +746,59 @@ export class PiAcpSession {
       }
 
       case 'agent_end': {
+        // Before resolving the prompt turn, emit usage telemetry in three forms so any
+        // client can show something useful:
+        //
+        //   1. `usage_update` (ACP ≥0.14, gated behind Zed's AcpBetaFeatureFlag) — drives
+        //      the circular context-window ring and cost chip in Zed. `used`/`size` are
+        //      based on the last assistant prompt (input + cacheRead + cacheWrite) vs the
+        //      model's contextWindow.
+        //   2. `session_info_update` with `_meta.piAcp.usage` — structured data other
+        //      clients / tools can read even without the beta flag.
+        //   3. An inline `agent_message_chunk` status line — visible in any client. Can
+        //      be suppressed by `PI_ACP_HIDE_USAGE_STATUS=1`.
+        const snap = this.snapshotUsage()
+        const lastPromptTokens = this.lastAssistantUsage
+          ? this.lastAssistantUsage.input +
+            this.lastAssistantUsage.cacheRead +
+            this.lastAssistantUsage.cacheWrite
+          : 0
+
+        if (this.contextWindow && this.contextWindow > 0) {
+          this.emit({
+            sessionUpdate: 'usage_update',
+            used: Math.min(lastPromptTokens, this.contextWindow),
+            size: this.contextWindow,
+            cost:
+              snap.sessionCost > 0
+                ? { amount: snap.sessionCost, currency: 'USD' }
+                : null
+          })
+        }
+
+        this.emit({
+          sessionUpdate: 'session_info_update',
+          updatedAt: new Date().toISOString(),
+          _meta: {
+            piAcp: {
+              usage: snap,
+              model: this.currentModelId,
+              queueDepth: this.turnQueue.length,
+              running: false
+            }
+          }
+        })
+
+        if (process.env.PI_ACP_HIDE_USAGE_STATUS !== '1' && snap.sessionTotalTokens > 0) {
+          const text = formatUsageStatus(snap, { includeSessionTotal: true })
+          if (text) {
+            this.emit({
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: `\n_${text}_\n` }
+            })
+          }
+        }
+
         // Ensure all updates derived from pi events are delivered before we resolve
         // the ACP `session/prompt` request.
         void this.flushEmits().finally(() => {

--- a/src/acp/translate/usage.ts
+++ b/src/acp/translate/usage.ts
@@ -1,0 +1,144 @@
+/**
+ * Translate pi assistant-message `usage` payloads (see @mariozechner/pi-ai `Usage`) into a
+ * compact per-turn + cumulative shape, plus a human-readable status line.
+ *
+ * Pi emits `message_end` events for each assistant message. On `assistant` messages the
+ * attached `usage` looks like:
+ *   {
+ *     input, output, cacheRead, cacheWrite, totalTokens,
+ *     cost: { input, output, cacheRead, cacheWrite, total }
+ *   }
+ *
+ * Since pi issues multiple assistant messages per ACP prompt turn (one per model call
+ * in the agent loop), we accumulate them across the turn and over the whole session.
+ */
+
+export type PiUsage = {
+  input: number
+  output: number
+  cacheRead: number
+  cacheWrite: number
+  totalTokens: number
+  cost: {
+    input: number
+    output: number
+    cacheRead: number
+    cacheWrite: number
+    total: number
+  }
+}
+
+export type UsageSnapshot = {
+  /** Tokens used by the current model's last assistant turn (final call of a prompt). */
+  lastTurnTokens: number
+  /** Cost of the current model's last assistant turn (final call of a prompt). */
+  lastTurnCost: number
+  /** Running total for the session. */
+  sessionInputTokens: number
+  sessionOutputTokens: number
+  sessionCacheReadTokens: number
+  sessionCacheWriteTokens: number
+  sessionTotalTokens: number
+  sessionCost: number
+  /** Size of the most recent assistant message's context window (if known). */
+  contextWindow: number | null
+  /**
+   * Best-effort context window fill % based on the **most recent** assistant message's
+   * input+cacheRead+cacheWrite. Pi reports per-call input, which after a tool loop
+   * approximates the prompt size going into the final model call.
+   */
+  contextFillRatio: number | null
+}
+
+export function emptyUsage(): PiUsage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+  }
+}
+
+export function parsePiUsage(raw: unknown): PiUsage | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+
+  const cost = (r.cost ?? {}) as Record<string, unknown>
+
+  return {
+    input: num(r.input),
+    output: num(r.output),
+    cacheRead: num(r.cacheRead),
+    cacheWrite: num(r.cacheWrite),
+    totalTokens: num(r.totalTokens),
+    cost: {
+      input: num(cost.input),
+      output: num(cost.output),
+      cacheRead: num(cost.cacheRead),
+      cacheWrite: num(cost.cacheWrite),
+      total: num(cost.total)
+    }
+  }
+}
+
+export function addUsage(a: PiUsage, b: PiUsage): PiUsage {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheWrite: a.cacheWrite + b.cacheWrite,
+    totalTokens: a.totalTokens + b.totalTokens,
+    cost: {
+      input: a.cost.input + b.cost.input,
+      output: a.cost.output + b.cost.output,
+      cacheRead: a.cost.cacheRead + b.cost.cacheRead,
+      cacheWrite: a.cost.cacheWrite + b.cost.cacheWrite,
+      total: a.cost.total + b.cost.total
+    }
+  }
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+
+function formatCost(n: number): string {
+  if (n === 0) return '$0.00'
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  if (n < 1) return `$${n.toFixed(3)}`
+  return `$${n.toFixed(2)}`
+}
+
+/**
+ * Render a compact one-line status suitable for a client that only displays text.
+ *
+ * Example: `↓ 1.2k · ↑ 342 · cache r 8.5k / w 200 · $0.024 · ctx 3% (1M)`
+ */
+export function formatUsageStatus(snap: UsageSnapshot, opts?: { includeSessionTotal?: boolean }): string {
+  const parts: string[] = []
+
+  parts.push(`↓ ${formatTokens(snap.sessionInputTokens)}`)
+  parts.push(`↑ ${formatTokens(snap.sessionOutputTokens)}`)
+
+  if (snap.sessionCacheReadTokens || snap.sessionCacheWriteTokens) {
+    parts.push(`cache r ${formatTokens(snap.sessionCacheReadTokens)} / w ${formatTokens(snap.sessionCacheWriteTokens)}`)
+  }
+
+  if (snap.sessionCost > 0) parts.push(formatCost(snap.sessionCost))
+
+  if (snap.contextFillRatio !== null && snap.contextWindow) {
+    const pct = Math.min(100, Math.max(0, Math.round(snap.contextFillRatio * 100)))
+    parts.push(`ctx ${pct}% (${formatTokens(snap.contextWindow)})`)
+  }
+
+  if (opts?.includeSessionTotal && snap.lastTurnTokens) {
+    parts.push(`turn ${formatTokens(snap.lastTurnTokens)} / ${formatCost(snap.lastTurnCost)}`)
+  }
+
+  return parts.join(' · ')
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+export type PiAcpVersionInfo = {
+  /** Package version from the installed package.json. */
+  packageVersion: string
+  /** Short git SHA when running from a git checkout, else null. */
+  gitShortSha: string | null
+  /** Whether the working tree has uncommitted changes at build time. */
+  gitDirty: boolean
+  /** Build file modification time (UTC ISO). */
+  buildTime: string | null
+  /** `true` when running from a `node <path>/src` or tsx dev invocation. */
+  devMode: boolean
+  /** User-supplied tag via PI_ACP_VERSION_TAG env, if any. */
+  tag: string | null
+  /** Absolute path to the resolved package.json. */
+  packageRoot: string | null
+}
+
+let cached: PiAcpVersionInfo | null = null
+
+export function getVersionInfo(): PiAcpVersionInfo {
+  if (cached) return cached
+
+  const selfDir = (() => {
+    try {
+      return dirname(fileURLToPath(import.meta.url))
+    } catch {
+      return process.cwd()
+    }
+  })()
+
+  const pkg = findNearestPackageJson(selfDir)
+  const packageVersion = pkg?.data?.version ? String(pkg.data.version) : '0.0.0'
+  const packageRoot = pkg?.path ? dirname(pkg.path) : null
+
+  const git = packageRoot ? readGitInfo(packageRoot) : { sha: null, dirty: false }
+
+  // Build time = mtime of the entry file (`dist/index.js`), or package.json
+  // as a fallback. Stable across reboots and meaningful for local iteration.
+  let buildTime: string | null = null
+  const entryCandidates = [
+    packageRoot ? join(packageRoot, 'dist', 'index.js') : null,
+    pkg?.path ?? null
+  ].filter((p): p is string => typeof p === 'string' && existsSync(p))
+  for (const p of entryCandidates) {
+    try {
+      buildTime = statSync(p).mtime.toISOString()
+      break
+    } catch {
+      // ignore
+    }
+  }
+
+  const devMode = /\/src(\/|$)/.test(selfDir) || selfDir.endsWith('/src')
+
+  cached = {
+    packageVersion,
+    gitShortSha: git.sha,
+    gitDirty: git.dirty,
+    buildTime,
+    devMode,
+    tag: process.env.PI_ACP_VERSION_TAG?.trim() || null,
+    packageRoot
+  }
+  return cached
+}
+
+/**
+ * Short human-readable identifier suitable for a title bar or banner header.
+ *
+ * Examples:
+ *   - "pi-acp v0.0.26"
+ *   - "pi-acp v0.0.26+abc1234"
+ *   - "pi-acp v0.0.26+abc1234-dirty (dev)"
+ *   - "pi-acp v0.0.26 [my-branch]"
+ */
+export function formatVersionLabel(info: PiAcpVersionInfo = getVersionInfo()): string {
+  const parts: string[] = [`pi-acp v${info.packageVersion}`]
+
+  if (info.gitShortSha) {
+    parts[0] += `+${info.gitShortSha}${info.gitDirty ? '-dirty' : ''}`
+  }
+
+  const flags: string[] = []
+  if (info.devMode) flags.push('dev')
+  if (info.tag) flags.push(info.tag)
+  if (flags.length) parts.push(`(${flags.join(', ')})`)
+
+  return parts.join(' ')
+}
+
+/**
+ * Multi-line block with every known identifier. Used by the `/version` command
+ * and embedded in the startup banner.
+ */
+export function formatVersionBlock(info: PiAcpVersionInfo = getVersionInfo()): string {
+  const lines: string[] = []
+  lines.push(formatVersionLabel(info))
+
+  if (info.buildTime) lines.push(`  build: ${info.buildTime}`)
+  if (info.packageRoot) lines.push(`  root:  ${info.packageRoot}`)
+  if (info.gitShortSha) lines.push(`  git:   ${info.gitShortSha}${info.gitDirty ? ' (dirty)' : ''}`)
+
+  return lines.join('\n')
+}
+
+/** Version string suitable for the `agentInfo.version` field in the initialize response. */
+export function getAgentInfoVersion(info: PiAcpVersionInfo = getVersionInfo()): string {
+  if (info.gitShortSha) {
+    return `${info.packageVersion}+${info.gitShortSha}${info.gitDirty ? '.dirty' : ''}`
+  }
+  return info.packageVersion
+}
+
+// --- internals ---------------------------------------------------------------
+
+function findNearestPackageJson(startDir: string): {
+  path: string
+  data: { name?: string; version?: string }
+} | null {
+  let dir = startDir
+  for (let i = 0; i < 8; i++) {
+    const p = join(dir, 'package.json')
+    if (existsSync(p)) {
+      try {
+        const raw = readFileSync(p, 'utf-8')
+        const data = JSON.parse(raw)
+        if (data && typeof data === 'object' && (data as any).name === 'pi-acp') {
+          return { path: p, data: data as any }
+        }
+      } catch {
+        // fall through to the parent dir
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+function readGitInfo(cwd: string): { sha: string | null; dirty: boolean } {
+  // Only bother if a `.git` exists on the resolved package root. Published npm
+  // packages won't have one, so we skip shelling out.
+  if (!existsSync(join(cwd, '.git'))) return { sha: null, dirty: false }
+
+  const sha = (() => {
+    const r = spawnSync('git', ['-C', cwd, 'rev-parse', '--short=7', 'HEAD'], {
+      encoding: 'utf-8',
+      timeout: 400
+    })
+    const out = String(r.stdout ?? '').trim()
+    return out && /^[0-9a-f]{6,}$/i.test(out) ? out : null
+  })()
+
+  const dirty = (() => {
+    const r = spawnSync('git', ['-C', cwd, 'status', '--porcelain'], {
+      encoding: 'utf-8',
+      timeout: 400
+    })
+    return String(r.stdout ?? '').trim().length > 0
+  })()
+
+  return { sha, dirty }
+}

--- a/test/component/session-diff.test.ts
+++ b/test/component/session-diff.test.ts
@@ -7,6 +7,162 @@ import { join } from 'node:path'
 import { PiAcpSession } from '../../src/acp/session.js'
 import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
 
+test('PiAcpSession: emits ACP diff content for write tool against a new file', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-write-new-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'new.txt')
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: dir,
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'tool_execution_start', toolCallId: 'w1', toolName: 'write', args: { path: 'new.txt' } })
+
+  writeFileSync(filePath, 'hello world\n', 'utf8')
+
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'w1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'ok' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = conn.updates.find(
+    u => (u.update as any).toolCallId === 'w1' && u.update.sessionUpdate === 'tool_call_update'
+  )
+  assert.ok(end, 'expected tool_call_update for write completion')
+
+  const content = (end!.update as any).content as any[]
+  assert.ok(Array.isArray(content), 'expected content array')
+  const diff = content.find(c => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item for new file')
+
+  assert.equal(diff.path, 'new.txt')
+  assert.equal(diff.oldText, '')
+  assert.equal(diff.newText, 'hello world\n')
+})
+
+test('PiAcpSession: emits ACP diff content for write tool overwriting an existing file', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-write-existing-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'existing.txt')
+  writeFileSync(filePath, 'v1\n', 'utf8')
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: dir,
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'tool_execution_start', toolCallId: 'w2', toolName: 'write', args: { path: 'existing.txt' } })
+
+  writeFileSync(filePath, 'v2\n', 'utf8')
+
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'w2',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'ok' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = conn.updates.find(
+    u => (u.update as any).toolCallId === 'w2' && u.update.sessionUpdate === 'tool_call_update'
+  )
+  const diff = ((end!.update as any).content as any[]).find(c => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item for overwrite')
+
+  assert.equal(diff.path, 'existing.txt')
+  assert.equal(diff.oldText, 'v1\n')
+  assert.equal(diff.newText, 'v2\n')
+})
+
+test('PiAcpSession: wraps bash tool output in a fenced shell code block', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'tool_execution_start', toolCallId: 'b1', toolName: 'bash', args: { cmd: 'echo hi' } })
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'b1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'hi' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = conn.updates.find(
+    u => (u.update as any).toolCallId === 'b1' && (u.update as any).status === 'completed'
+  )
+  assert.ok(end, 'expected completed tool_call_update for bash')
+
+  const content = (end!.update as any).content as any[]
+  assert.ok(Array.isArray(content) && content.length === 1, 'expected a single content item')
+  const item = content[0]
+  assert.equal(item.type, 'content')
+  assert.equal(item.content.type, 'text')
+  assert.ok(item.content.text.startsWith('```shell\n'), 'expected shell fence prefix')
+  assert.ok(item.content.text.endsWith('```'), 'expected closing fence')
+  assert.ok(item.content.text.includes('\nhi\n'), 'expected stdout preserved between fences')
+})
+
+test('PiAcpSession: escapes bash output containing backticks with a longer fence', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'tool_execution_start', toolCallId: 'b2', toolName: 'bash', args: { cmd: 'cat file.md' } })
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 'b2',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'line\n```\ninner\n```\nafter' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = conn.updates.find(
+    u => (u.update as any).toolCallId === 'b2' && (u.update as any).status === 'completed'
+  )
+  const text = ((end!.update as any).content as any[])[0]!.content.text as string
+  assert.ok(text.startsWith('````shell\n'), 'expected at least 4 backticks when inner has 3')
+  assert.ok(text.endsWith('````'), 'expected matching closing fence length')
+})
+
 test('PiAcpSession: emits ACP diff content for edit tool when file changes', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/unit/client-native-usage-detection.test.ts
+++ b/test/unit/client-native-usage-detection.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+
+/**
+ * `initialize` should record whether the client renders `usage_update` natively,
+ * based on `clientInfo.name`. This is later forwarded to `PiAcpSession` to suppress
+ * the redundant inline status line.
+ */
+function getFlag(agent: PiAcpAgent): boolean {
+  return (agent as unknown as { clientRendersUsageNatively: boolean }).clientRendersUsageNatively
+}
+
+test('initialize: marks clientRendersUsageNatively=true for Zed', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  await agent.initialize({ protocolVersion: 1, clientInfo: { name: 'zed' } } as any)
+  assert.equal(getFlag(agent), true)
+})
+
+test('initialize: is case-insensitive on clientInfo.name', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  await agent.initialize({ protocolVersion: 1, clientInfo: { name: 'Zed' } } as any)
+  assert.equal(getFlag(agent), true)
+})
+
+test('initialize: marks clientRendersUsageNatively=false for unknown clients', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  await agent.initialize({ protocolVersion: 1, clientInfo: { name: 'some-other-client' } } as any)
+  assert.equal(getFlag(agent), false)
+})
+
+test('initialize: defaults to false when clientInfo is absent', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  await agent.initialize({ protocolVersion: 1 } as any)
+  assert.equal(getFlag(agent), false)
+})

--- a/test/unit/enable-extension-commands.test.ts
+++ b/test/unit/enable-extension-commands.test.ts
@@ -1,0 +1,70 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getEnableExtensionCommands } from '../../src/acp/pi-settings.js'
+
+let originalEnv: string | undefined
+let originalAgentDir: string | undefined
+let tmpAgentDir: string | null = null
+let tmpCwd: string | null = null
+
+beforeEach(() => {
+  originalEnv = process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS
+  originalAgentDir = process.env.PI_CODING_AGENT_DIR
+  delete process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS
+
+  tmpAgentDir = mkdtempSync(join(tmpdir(), 'pi-acp-agent-'))
+  tmpCwd = mkdtempSync(join(tmpdir(), 'pi-acp-cwd-'))
+  process.env.PI_CODING_AGENT_DIR = tmpAgentDir
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS
+  else process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS = originalEnv
+
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir
+
+  if (tmpAgentDir) rmSync(tmpAgentDir, { recursive: true, force: true })
+  if (tmpCwd) rmSync(tmpCwd, { recursive: true, force: true })
+  tmpAgentDir = null
+  tmpCwd = null
+})
+
+test('getEnableExtensionCommands: defaults to true when nothing is configured', () => {
+  assert.equal(getEnableExtensionCommands(tmpCwd!), true)
+})
+
+test('getEnableExtensionCommands: env var "false" wins over default', () => {
+  process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS = 'false'
+  assert.equal(getEnableExtensionCommands(tmpCwd!), false)
+})
+
+test('getEnableExtensionCommands: env var "true" is respected', () => {
+  process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS = 'true'
+  assert.equal(getEnableExtensionCommands(tmpCwd!), true)
+})
+
+test('getEnableExtensionCommands: env var takes precedence over project + global settings', () => {
+  writeFileSync(join(tmpAgentDir!, 'settings.json'), JSON.stringify({ enableExtensionCommands: false }))
+  mkdirSync(join(tmpCwd!, '.pi'), { recursive: true })
+  writeFileSync(join(tmpCwd!, '.pi', 'settings.json'), JSON.stringify({ enableExtensionCommands: false }))
+
+  process.env.PI_ACP_ENABLE_EXTENSION_COMMANDS = 'true'
+  assert.equal(getEnableExtensionCommands(tmpCwd!), true)
+})
+
+test('getEnableExtensionCommands: project setting overrides global setting', () => {
+  writeFileSync(join(tmpAgentDir!, 'settings.json'), JSON.stringify({ enableExtensionCommands: true }))
+  mkdirSync(join(tmpCwd!, '.pi'), { recursive: true })
+  writeFileSync(join(tmpCwd!, '.pi', 'settings.json'), JSON.stringify({ enableExtensionCommands: false }))
+
+  assert.equal(getEnableExtensionCommands(tmpCwd!), false)
+})
+
+test('getEnableExtensionCommands: non-boolean setting value falls back to default', () => {
+  writeFileSync(join(tmpAgentDir!, 'settings.json'), JSON.stringify({ enableExtensionCommands: 'yes' }))
+  assert.equal(getEnableExtensionCommands(tmpCwd!), true)
+})

--- a/test/unit/usage-telemetry.test.ts
+++ b/test/unit/usage-telemetry.test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+// Helpers -------------------------------------------------------------
+
+function setTimeoutFlush(): Promise<void> {
+  // Allow the serialized lastEmit chain + scheduled emits to drain.
+  return new Promise(resolve => setTimeout(resolve, 10))
+}
+
+function findUpdate(
+  conn: FakeAgentSideConnection,
+  match: (u: any) => boolean
+) {
+  for (let i = conn.updates.length - 1; i >= 0; i -= 1) {
+    const u = (conn.updates[i] as any).update
+    if (match(u)) return u
+  }
+  return undefined
+}
+
+// Tests ---------------------------------------------------------------
+
+test('PiAcpSession: emits usage snapshot + status line on agent_end', async () => {
+  const prevHide = process.env.PI_ACP_HIDE_USAGE_STATUS
+  delete process.env.PI_ACP_HIDE_USAGE_STATUS
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+
+    const session = new PiAcpSession({
+      sessionId: 's1',
+      cwd: '/tmp/project',
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: [],
+      contextWindow: 100_000,
+      modelId: 'anthropic/claude-sonnet-4'
+    })
+
+    // Kick off a turn.
+    const turn = session.prompt('hi')
+
+    // Simulate pi events: agent_start → message_update (text) → message_end (usage) → agent_end.
+    proc.emit({ type: 'agent_start' })
+    proc.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+        usage: {
+          input: 1234,
+          output: 567,
+          cacheRead: 8500,
+          cacheWrite: 200,
+          totalTokens: 10501,
+          cost: { input: 0.004, output: 0.008, cacheRead: 0.001, cacheWrite: 0.00025, total: 0.01325 }
+        }
+      }
+    })
+    proc.emit({ type: 'agent_end' })
+
+    assert.equal(await turn, 'end_turn')
+    await setTimeoutFlush()
+
+    // Structured meta present.
+    const info = findUpdate(conn, u => u?.sessionUpdate === 'session_info_update' && u?._meta?.piAcp?.usage)
+    assert.ok(info, 'expected session_info_update with _meta.piAcp.usage')
+    const usage = info._meta.piAcp.usage
+    assert.equal(usage.sessionInputTokens, 1234)
+    assert.equal(usage.sessionOutputTokens, 567)
+    assert.equal(usage.sessionCost, 0.01325)
+    assert.equal(usage.contextWindow, 100_000)
+    assert.ok(usage.contextFillRatio !== null && usage.contextFillRatio > 0)
+
+    // First-class ACP usage_update (the one that drives Zed's context ring).
+    const ring = findUpdate(conn, u => u?.sessionUpdate === 'usage_update')
+    assert.ok(ring, 'expected usage_update')
+    assert.equal(ring.size, 100_000)
+    // used = last prompt = input + cacheRead + cacheWrite
+    assert.equal(ring.used, 1234 + 8500 + 200)
+    assert.equal(ring.cost.currency, 'USD')
+    assert.ok(Math.abs(ring.cost.amount - 0.01325) < 1e-9)
+
+    // Status chunk present with human-readable summary.
+    const chunk = findUpdate(
+      conn,
+      u => u?.sessionUpdate === 'agent_message_chunk' && typeof u?.content?.text === 'string' && u.content.text.includes('ctx')
+    )
+    assert.ok(chunk, 'expected a usage status chunk with ctx fill')
+  } finally {
+    if (prevHide === undefined) delete process.env.PI_ACP_HIDE_USAGE_STATUS
+    else process.env.PI_ACP_HIDE_USAGE_STATUS = prevHide
+  }
+})
+
+test('PiAcpSession: PI_ACP_HIDE_USAGE_STATUS=1 suppresses the status chunk but keeps the meta', async () => {
+  process.env.PI_ACP_HIDE_USAGE_STATUS = '1'
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+
+    const session = new PiAcpSession({
+      sessionId: 's2',
+      cwd: '/tmp/project',
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: [],
+      contextWindow: null,
+      modelId: null
+    })
+
+    const turn = session.prompt('hi')
+    proc.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0001 } }
+      }
+    })
+    proc.emit({ type: 'agent_end' })
+    assert.equal(await turn, 'end_turn')
+    await setTimeoutFlush()
+
+    // No status chunk emitted.
+    const chunk = findUpdate(
+      conn,
+      u => u?.sessionUpdate === 'agent_message_chunk' && typeof u?.content?.text === 'string' && u.content.text.includes('ctx')
+    )
+    assert.equal(chunk, undefined)
+
+    // But the meta is still there.
+    const info = findUpdate(conn, u => u?.sessionUpdate === 'session_info_update' && u?._meta?.piAcp?.usage)
+    assert.ok(info)
+  } finally {
+    delete process.env.PI_ACP_HIDE_USAGE_STATUS
+  }
+})

--- a/test/unit/usage-telemetry.test.ts
+++ b/test/unit/usage-telemetry.test.ts
@@ -98,6 +98,117 @@ test('PiAcpSession: emits usage snapshot + status line on agent_end', async () =
   }
 })
 
+test('PiAcpSession: suppresses status chunk when clientRendersUsageNatively=true (but keeps usage_update + meta)', async () => {
+  const prevHide = process.env.PI_ACP_HIDE_USAGE_STATUS
+  const prevMode = process.env.PI_ACP_USAGE_STATUS
+  delete process.env.PI_ACP_HIDE_USAGE_STATUS
+  delete process.env.PI_ACP_USAGE_STATUS
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+
+    const session = new PiAcpSession({
+      sessionId: 's-native',
+      cwd: '/tmp/project',
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: [],
+      contextWindow: 100_000,
+      modelId: 'anthropic/claude-sonnet-4',
+      clientRendersUsageNatively: true
+    })
+
+    const turn = session.prompt('hi')
+    proc.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 }
+        }
+      }
+    })
+    proc.emit({ type: 'agent_end' })
+    assert.equal(await turn, 'end_turn')
+    await setTimeoutFlush()
+
+    // No duplicate text status line.
+    const chunk = findUpdate(
+      conn,
+      u => u?.sessionUpdate === 'agent_message_chunk' && typeof u?.content?.text === 'string' && u.content.text.includes('ctx')
+    )
+    assert.equal(chunk, undefined, 'status chunk should be suppressed when the client renders usage natively')
+
+    // But usage_update (the ring) and _meta usage are still emitted.
+    assert.ok(findUpdate(conn, u => u?.sessionUpdate === 'usage_update'))
+    assert.ok(findUpdate(conn, u => u?.sessionUpdate === 'session_info_update' && u?._meta?.piAcp?.usage))
+  } finally {
+    if (prevHide === undefined) delete process.env.PI_ACP_HIDE_USAGE_STATUS
+    else process.env.PI_ACP_HIDE_USAGE_STATUS = prevHide
+    if (prevMode === undefined) delete process.env.PI_ACP_USAGE_STATUS
+    else process.env.PI_ACP_USAGE_STATUS = prevMode
+  }
+})
+
+test('PiAcpSession: PI_ACP_USAGE_STATUS=always forces the text line even for native-usage clients', async () => {
+  const prevMode = process.env.PI_ACP_USAGE_STATUS
+  process.env.PI_ACP_USAGE_STATUS = 'always'
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+
+    const session = new PiAcpSession({
+      sessionId: 's-force',
+      cwd: '/tmp/project',
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: [],
+      contextWindow: 100_000,
+      modelId: 'anthropic/claude-sonnet-4',
+      clientRendersUsageNatively: true
+    })
+
+    const turn = session.prompt('hi')
+    proc.emit({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 }
+        }
+      }
+    })
+    proc.emit({ type: 'agent_end' })
+    assert.equal(await turn, 'end_turn')
+    await setTimeoutFlush()
+
+    const chunk = findUpdate(
+      conn,
+      u => u?.sessionUpdate === 'agent_message_chunk' && typeof u?.content?.text === 'string' && u.content.text.includes('ctx')
+    )
+    assert.ok(chunk, 'status chunk should be emitted when PI_ACP_USAGE_STATUS=always')
+  } finally {
+    if (prevMode === undefined) delete process.env.PI_ACP_USAGE_STATUS
+    else process.env.PI_ACP_USAGE_STATUS = prevMode
+  }
+})
+
 test('PiAcpSession: PI_ACP_HIDE_USAGE_STATUS=1 suppresses the status chunk but keeps the meta', async () => {
   process.env.PI_ACP_HIDE_USAGE_STATUS = '1'
 


### PR DESCRIPTION
## Summary

Several small improvements to make the adapter feel more native inside Zed (and other ACP clients that support the newer session/update shapes).

## Changes

### Session & protocol surface
- **Session metadata bootstrap** — after `session/new` resolves, emit `session_info_update` (title + `_meta.piAcp` with version, git sha, current model, contextWindow, sessionFile) and an initial `current_mode_update` for the thinking mode.
- **`/version` slash command** — new `src/version.ts` embeds version/git sha/build time; `/version` prints a fenced block with the build info.
- **Context-aware session seeding** — seed session with `currentModelId` + `contextWindow` from pi state so usage % is accurate from the first turn.
- **Expose extension-sourced slash commands** — `/worktree`, `/plannotator`, `/mcp`, `/jarvis`, etc. were being filtered out by a hardcoded `includeExtensionCommands: false`. They are now forwarded to the ACP client so they appear in the slash command palette. Configurable via pi setting `enableExtensionCommands` (global or project) or env var `PI_ACP_ENABLE_EXTENSION_COMMANDS`. Defaults to `true` so extension commands are discoverable the same way skill commands already are.

### Usage telemetry
- **New `src/acp/translate/usage.ts`** accumulates pi `message_end` usage across an ACP prompt turn and emits:
  1. `usage_update` — drives Zed's context-window ring and cost chip (ACP ≥0.14).
  2. `session_info_update` with `_meta.piAcp.usage` — structured data for non-beta clients.
  3. An inline text status line — fallback for clients that only render text.
- **Auto-hide the text status line for clients that render `usage_update` natively.** Detect known native-rendering clients (currently `zed`) at `initialize` time from `clientInfo.name` and suppress the inline text fallback to avoid duplicating the ring/cost chip.
  - New env var `PI_ACP_USAGE_STATUS = auto (default) | always | never` for manual override.
  - `PI_ACP_HIDE_USAGE_STATUS=1` is preserved as a legacy alias for `never`.

### Tool-call rendering
- **Structured diffs for `edit` / `write`** — snapshot file contents before the tool runs and emit ACP `ToolCallContent {type:"diff"}` on completion (instead of pi's pre-formatted diff string). Supports new-file creation (`write` with empty `oldText`).
- **Fenced bash output** — wrap `bash` tool stdout in a code fence sized to the longest backtick run so Zed's markdown renderer doesn't reflow shell output.

## Tests

- `test/unit/usage-telemetry.test.ts` — usage accumulation + snapshot shape, status-line gating (native client / `always` / `never` / legacy env var).
- `test/unit/client-native-usage-detection.test.ts` — `initialize` records `clientRendersUsageNatively` from `clientInfo.name` (Zed, case-insensitive, unknown clients, missing clientInfo).
- `test/unit/enable-extension-commands.test.ts` — `getEnableExtensionCommands` resolution order (env var, project > global settings, default, non-boolean fallback).
- `test/component/session-diff.test.ts` — edit/write snapshot → structured diff flow, bash output fencing.

## Notes

- Based on latest `upstream/main` (`d6f2991` — 0.0.26), no rebase needed.
- No changes to pi itself; all additions are ACP-side.
- Detection of native-usage clients is name-based since ACP doesn't currently expose a `usage_update` capability flag. Conservative by design: unknown clients still get the text fallback.
- **Behavior change worth calling out:** extension-sourced commands now default to **exposed** (previously hardcoded hidden). If upstream prefers opt-in, flipping the default in `getEnableExtensionCommands` to `false` is a one-line change.
