### PR TITLE
feat: forward non-pi-acp CLI arguments to pi executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,42 @@ You can add the environment variable in the Zed settings with:
   }
 ```
 
+### Forwarding arguments to pi
+
+Any command-line arguments that are not specific to `pi-acp` are forwarded to the underlying `pi` executable. This is useful for passing flags like `--model`, `--provider`, or extension's specific flags when starting a session.
+
+The following arguments are managed by `pi-acp` and will be stripped before forwarding:
+
+- `--mode`
+- `--session`
+- `--no-themes`
+- `--terminal-login`
+
+You can pass arguments directly:
+
+```bash
+pi-acp --model opencode-go/kimi-k2.6
+```
+
+Or use `--` to explicitly separate `pi-acp` arguments from `pi` arguments:
+
+```bash
+pi-acp --terminal-login -- --no-extensions --no-skills
+```
+
+In your ACP client configuration (e.g. Zed), add them to the `args` array:
+
+```json
+  "agent_servers": {
+    "pi": {
+      "type": "custom",
+      "command": "pi-acp",
+      "args": ["--model", "opencode-go/kimi-k2.6"],
+      "env": {}
+    }
+  }
+```
+
 ### Slash commands
 
 `pi-acp` supports slash commands:

--- a/src/pi-rpc/forward-args.ts
+++ b/src/pi-rpc/forward-args.ts
@@ -1,0 +1,32 @@
+export function getForwardedPiArgs(argv: string[] = process.argv.slice(2)): string[] {
+  const out: string[] = []
+  let i = 0
+  while (i < argv.length) {
+    const arg = argv[i]
+
+    if (arg === '--') {
+      out.push(...argv.slice(i + 1))
+      break
+    }
+
+    if (arg === '--terminal-login' || arg === '--no-themes') {
+      i++
+      continue
+    }
+
+    if (arg === '--mode' || arg === '--session') {
+      i += 2
+      continue
+    }
+
+    if (arg.startsWith('--mode=') || arg.startsWith('--session=')) {
+      i++
+      continue
+    }
+
+    out.push(arg)
+    i++
+  }
+
+  return out
+}

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import * as readline from 'node:readline'
 import { getPiCommand, shouldUseShellForPiCommand } from './command.js'
+import { getForwardedPiArgs } from './forward-args.js'
 
 export class PiRpcSpawnError extends Error {
   /** Underlying spawn error code, e.g. ENOENT, EACCES */
@@ -131,6 +132,7 @@ export class PiRpcProcess {
     // (e.g. MCP extensions, prompt templates for workflows).
     const args = ['--mode', 'rpc', '--no-themes']
     if (params.sessionPath) args.push('--session', params.sessionPath)
+    args.push(...getForwardedPiArgs())
 
     const child = spawn(cmd, args, {
       cwd: params.cwd,

--- a/test/unit/forward-args.test.ts
+++ b/test/unit/forward-args.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { getForwardedPiArgs } from '../../src/pi-rpc/forward-args.js'
+
+test('getForwardedPiArgs: forwards unknown long flags', () => {
+  assert.deepEqual(getForwardedPiArgs(['--model', 'o4-mini']), ['--model', 'o4-mini'])
+})
+
+test('getForwardedPiArgs: strips --terminal-login', () => {
+  assert.deepEqual(getForwardedPiArgs(['--terminal-login']), [])
+})
+
+test('getForwardedPiArgs: strips --mode and its value', () => {
+  assert.deepEqual(getForwardedPiArgs(['--mode', 'cli', '--foo']), ['--foo'])
+})
+
+test('getForwardedPiArgs: strips --mode=value form', () => {
+  assert.deepEqual(getForwardedPiArgs(['--mode=cli', '--foo']), ['--foo'])
+})
+
+test('getForwardedPiArgs: strips --session and its value', () => {
+  assert.deepEqual(getForwardedPiArgs(['--session', '/tmp/x', '--foo']), ['--foo'])
+})
+
+test('getForwardedPiArgs: strips --session=value form', () => {
+  assert.deepEqual(getForwardedPiArgs(['--session=/tmp/x', '--foo']), ['--foo'])
+})
+
+test('getForwardedPiArgs: strips --no-themes', () => {
+  assert.deepEqual(getForwardedPiArgs(['--no-themes', '--foo']), ['--foo'])
+})
+
+test('getForwardedPiArgs: everything after -- forwards unconditionally', () => {
+  assert.deepEqual(getForwardedPiArgs(['--mode', 'rpc', '--', '--mode', 'cli']), ['--mode', 'cli'])
+})
+
+test('getForwardedPiArgs: returns empty for no args', () => {
+  assert.deepEqual(getForwardedPiArgs([]), [])
+})


### PR DESCRIPTION

## Forward non-pi-acp CLI arguments to `pi` executable

### Summary
Allows users to pass custom CLI flags (e.g. `--model`, `--provider`) through `pi-acp` to the underlying `pi` process. pi-acp-managed flags (`--mode`, `--session`, `--no-themes`, `--terminal-login`) are stripped before forwarding.

### Motivation
Currently, `pi-acp` hardcodes the `pi` spawn args to `--mode rpc --no-themes [--session <path>]`. Users who want to pass custom `pi`-native and extension flags have no way to do so when running through ACP clients like Zed.

### Changes

- **`src/pi-rpc/forward-args.ts`** (new): Parses `process.argv`, strips pi-acp-managed flags, forwards the rest. Supports `--` separator for explicit boundary.
- **`src/pi-rpc/process.ts`**: Appends forwarded args after mandatory args in `spawn()`.
- **`test/unit/forward-args.test.ts`** (new): 9 tests covering unknown flags, stripped flags, `=value` forms, and `--` passthrough.
- **`README.md`**: Added "Forwarding arguments to pi" section with usage examples and Zed config snippet.

### Usage examples

```bash
# Direct forwarding
pi-acp --model opencode-go/kimi-k2.6

# Explicit separator
pi-acp --terminal-login -- --no-extensions --no-skills
```

### Zed configuration

```json
"agent_servers": {
  "pi": {
    "type": "custom",
    "command": "pi-acp",
    "args": ["--model", "opencode-go/kimi-k2.6"],
    "env": {}
  }
}
```

### Test results

All new tests pass:

```
✔ getForwardedPiArgs: forwards unknown long flags (2.868967ms)
✔ getForwardedPiArgs: strips --terminal-login (0.444216ms)
✔ getForwardedPiArgs: strips --mode and its value (0.211212ms)
✔ getForwardedPiArgs: strips --mode=value form (0.372157ms)
✔ getForwardedPiArgs: strips --session and its value (0.392756ms)
✔ getForwardedPiArgs: strips --session=value form (0.462753ms)
✔ getForwardedPiArgs: strips --no-themes (0.425551ms)
✔ getForwardedPiArgs: everything after -- forwards unconditionally (0.38946ms)
✔ getForwardedPiArgs: returns empty for no args (0.339342ms)
```

### Backwards compatibility

No breaking changes. When `pi-acp` is launched with no extra args, behavior is identical to before (forwards empty array).
