### PR TITLE
feat: add automatic ACP session titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Expect some minor breaking changes.
 - Skills are loaded by pi directly and are available in ACP sessions
 - (Zed) `pi-acp` emits “startup info” block into the session (pi version, context, skills, prompts, extensions - similar to `pi` in the terminal). You can disable it by setting `quietStartup: true` in pi settings (`~/.pi/agent/settings.json` or `<project>/.pi/settings.json`). When `quietStartup` is enabled, `pi-acp` will still emit a 'New version available' message if the installed pi version is outdated.
 - (Zed) Session history is supported in Zed starting with [`v0.225.0`](https://zed.dev/releases/preview/0.225.0). Session loading / history maps to pi's session files. Sessions can be resumed both in `pi` and in the ACP client.
+- (Zed) New sessions are automatically given a short title derived from the first user prompt by a best-effort background pi worker. Manual `/name <name>` titles are never overwritten.
 
 ## Prerequisites
 
@@ -114,6 +115,7 @@ Point your ACP client to the built `dist/index.js`:
 - `PI_ACP_ENABLE_EMBEDDED_CONTEXT=true` advertises ACP `promptCapabilities.embeddedContext` support to the client.
 - Default: unset/any other value means `false`.
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
+- `PI_ACP_AUTO_TITLE=false` disables automatic title generation from the first user prompt. Auto-title is enabled by default.
 
 You can add the environment variable in the Zed settings with:
 

--- a/docs/plans/2026-05-02-auto-thread-title.md
+++ b/docs/plans/2026-05-02-auto-thread-title.md
@@ -1,0 +1,86 @@
+# Auto Thread Title Generation Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Automatically set a short ACP/Zed thread title by spawning a separate Pi agent to summarize the user’s first real prompt.
+
+**Architecture:** `pi-acp` detects the first non-slash user prompt for a session, spawns an isolated `pi --mode rpc` process dedicated to title generation, asks it to produce a short title, persists that title through existing `set_session_name`, then emits ACP `session_info_update`. This happens asynchronously and must not block the main assistant turn.
+
+**Tech Stack:** TypeScript, Node.js, ACP SDK, existing `PiRpcProcess`, existing `session/update` flow, existing Pi RPC `set_session_name`.
+
+---
+
+## Checklist
+
+- [x] Create local checkout at `/Users/rico/dev/packages/pi-acp`.
+- [x] Create branch `auto-thread-title`.
+- [x] Save this implementation plan in `docs/plans/2026-05-02-auto-thread-title.md`.
+- [x] Install dependencies with `npm install` if needed.
+- [x] Add title helper tests in `test/title.test.ts`.
+- [x] Run title tests and verify they fail before implementation.
+- [x] Add `src/acp/title.ts` helper functions.
+- [x] Run title tests and verify they pass.
+- [x] Inspect existing `src/acp/session.ts`, `src/acp/agent.ts`, and `src/pi-rpc/process.ts`.
+- [x] Add auto-title session state and worker flow.
+- [x] Ensure `/name` marks the title as manually set and prevents overwrite.
+- [x] Add session-level behavior tests for first prompt, slash command skip, single-run guard, fallback, and manual override.
+- [x] Add README documentation and optional `PI_ACP_AUTO_TITLE=false` escape hatch.
+- [x] Run `npm run format`.
+- [x] Run `npm run lint`.
+- [x] Run `npm run typecheck`.
+- [x] Run `npm test`.
+- [x] Run `npm run build`.
+- [ ] Test via `pii-acp` wrapper by pointing it at the local built `pi-acp`.
+- [ ] If successful, prepare PR to upstream `pi-acp`.
+
+## Implementation Notes
+
+### Title generation behavior
+
+- Trigger only for the first non-empty, non-slash user prompt.
+- Spawn a separate Pi RPC process for title generation so the main conversation remains clean.
+- Ask for only a concise title: 3–7 words, no markdown, no quotes, no trailing punctuation.
+- Sanitize model output before use.
+- Fall back to a deterministic prompt-derived title if the title worker fails.
+- Persist through `set_session_name` on the main session.
+- Emit ACP:
+
+```ts
+session.emit({
+  sessionUpdate: 'session_info_update',
+  title,
+  updatedAt: new Date().toISOString()
+})
+```
+
+### Helper API
+
+Create `src/acp/title.ts` with:
+
+- `buildTitlePrompt(firstPrompt: string): string`
+- `sanitizeGeneratedTitle(raw: string): string`
+- `fallbackTitleFromPrompt(prompt: string): string`
+- `shouldAutoTitlePrompt(message: string): boolean`
+
+### Session integration
+
+Add session state:
+
+```ts
+private autoTitleStarted = false;
+private titleManuallySet = false;
+```
+
+Add methods:
+
+```ts
+maybeStartAutoTitle(firstPrompt: string): void
+private async generateAndSetTitle(firstPrompt: string): Promise<void>
+async setManualTitle(name: string): Promise<void>
+```
+
+Use `setManualTitle` from `/name` instead of directly calling `session.proc.setSessionName(name)`.
+
+### Verification
+
+Use local source checkout for development, then wire `pii-acp` to launch `/Users/rico/dev/packages/pi-acp/dist/index.js` for end-to-end Zed testing while preserving `varlock` behavior.

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -211,12 +211,19 @@ export class PiAcpAgent implements ACPAgent {
       }
 
       const fileCommands = loadSlashCommands(cwd)
+
+      // Replay full conversation history. Fetch before constructing the ACP session so
+      // existing named sessions don't get auto-renamed by the first resumed prompt.
+      const data = (await proc.getMessages()) as any
+      const messages = Array.isArray(data?.messages) ? data.messages : []
+
       const session = this.sessions.getOrCreate(sessionId, {
         cwd,
         mcpServers: opts?.mcpServers ?? [],
         conn: this.conn,
         proc,
-        fileCommands
+        fileCommands,
+        hasExistingTitle: hasSessionInfoTitle(messages)
       })
 
       this.lastSessionCwd = cwd
@@ -941,16 +948,17 @@ export class PiAcpAgent implements ACPAgent {
     const proc = session.proc
     const fileCommands = loadSlashCommands(params.cwd)
 
+    // Replay full conversation history. Fetch before constructing the ACP session so
+    // existing named sessions don't get auto-renamed by the first resumed prompt.
+    const data = (await proc.getMessages()) as any
+    const messages = Array.isArray(data?.messages) ? data.messages : []
+
     // (Optional) ensure mapping stays fresh.
     this.store.upsert({
       sessionId: params.sessionId,
       cwd: params.cwd,
       sessionFile: stored.sessionFile
     })
-
-    // Replay full conversation history.
-    const data = (await proc.getMessages()) as any
-    const messages = Array.isArray(data?.messages) ? data.messages : []
 
     for (const m of messages) {
       const role = String(m?.role ?? '')
@@ -1599,6 +1607,16 @@ function buildStartupInfo(opts: {
 
   // Do NOT include themes (per request).
   return md.join('\n').trim() + '\n'
+}
+
+function hasSessionInfoTitle(messages: unknown[]): boolean {
+  return messages.some(message => {
+    const record = message as { role?: unknown; name?: unknown; content?: unknown }
+    if (record.role !== 'session_info') return false
+    if (typeof record.name === 'string' && record.name.trim()) return true
+    const content = record.content as { name?: unknown } | undefined
+    return typeof content?.name === 'string' && content.name.trim().length > 0
+  })
 }
 
 function readNearestPackageJson(metaUrl: string): {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -4,6 +4,8 @@ import {
   type AgentSideConnection,
   type AuthenticateRequest,
   type CancelNotification,
+  type CloseSessionRequest,
+  type CloseSessionResponse,
   type InitializeRequest,
   type InitializeResponse,
   type ListSessionsRequest,
@@ -260,7 +262,8 @@ export class PiAcpAgent implements ACPAgent {
         sessionCapabilities: {
           // **UNSTABLE** ACP capability used by Zed's codex-acp adapter.
           // Enables a native session picker in clients that support it.
-          list: {}
+          list: {},
+          close: {}
         }
       }
     }
@@ -365,13 +368,6 @@ export class PiAcpAgent implements ACPAgent {
 
     if (preludeText)
       session.setStartupInfo(preludeText)
-
-      // Policy: within a single ACP connection (one client window), keep only one live pi subprocess.
-      // This avoids leaking subprocesses when clients start new sessions but don't explicitly close old ones.
-      // It does NOT affect other client windows because they run in separate agent processes.
-      //
-      // (Tests sometimes stub out `this.sessions`, so guard the call.)
-    ;(this.sessions as any).closeAllExcept?.(session.sessionId)
 
     const response = {
       sessionId: session.sessionId,
@@ -886,6 +882,11 @@ export class PiAcpAgent implements ACPAgent {
     await session.cancel()
   }
 
+  async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+    this.sessions.close(params.sessionId)
+    return {}
+  }
+
   async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
     // ACP: filter by cwd if provided.
     // Zed currently sends `{}` (no cwd), so we default to the last session cwd to
@@ -939,10 +940,6 @@ export class PiAcpAgent implements ACPAgent {
     })
     const proc = session.proc
     const fileCommands = loadSlashCommands(params.cwd)
-
-    // Policy: within a single ACP connection (one Zed window), keep only one live pi subprocess.
-    // (Tests sometimes stub out `this.sessions`, so guard the call.)
-    ;(this.sessions as any).closeAllExcept?.(session.sessionId)
 
     // (Optional) ensure mapping stays fresh.
     this.store.upsert({

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -521,7 +521,7 @@ export class PiAcpAgent implements ACPAgent {
         }
 
         try {
-          await session.proc.setSessionName(name)
+          await session.setManualTitle(name)
         } catch (e: any) {
           const msg = String(e?.message ?? e)
           const hint = /set_session_name/i.test(msg)
@@ -537,15 +537,6 @@ export class PiAcpAgent implements ACPAgent {
           })
           return { stopReason: 'end_turn' }
         }
-
-        await this.conn.sessionUpdate({
-          sessionId: session.sessionId,
-          update: {
-            sessionUpdate: 'session_info_update',
-            title: name,
-            updatedAt: new Date().toISOString()
-          }
-        })
 
         await this.conn.sessionUpdate({
           sessionId: session.sessionId,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -30,6 +30,7 @@ import { toolResultToText } from './translate/pi-tools.js'
 import { buildTitlePrompt, fallbackTitleFromPrompt, sanitizeGeneratedTitle, shouldAutoTitlePrompt } from './title.js'
 
 type TitleProcessFactory = (params: { cwd: string; piCommand?: string }) => Promise<PiRpcProcess>
+const DEFAULT_TITLE_TIMEOUT_MS = 30_000
 
 type SessionCreateParams = {
   cwd: string
@@ -37,6 +38,7 @@ type SessionCreateParams = {
   conn: AgentSideConnection
   fileCommands?: import('./slash-commands.js').FileSlashCommand[]
   piCommand?: string
+  hasExistingTitle?: boolean
 }
 
 export type StopReason = 'end_turn' | 'cancelled' | 'error'
@@ -172,7 +174,7 @@ export class SessionManager {
     const s = this.sessions.get(sessionId)
     if (!s) return
     try {
-      s.proc.dispose?.()
+      s.dispose()
     } catch {
       // ignore
     }
@@ -224,7 +226,8 @@ export class SessionManager {
       proc,
       conn: params.conn,
       fileCommands: params.fileCommands ?? [],
-      piCommand: params.piCommand
+      piCommand: params.piCommand,
+      hasExistingTitle: params.hasExistingTitle
     })
 
     this.sessions.set(sessionId, session)
@@ -252,7 +255,8 @@ export class SessionManager {
       proc: params.proc,
       conn: params.conn,
       fileCommands: params.fileCommands ?? [],
-      piCommand: params.piCommand
+      piCommand: params.piCommand,
+      hasExistingTitle: params.hasExistingTitle
     })
 
     this.sessions.set(sessionId, session)
@@ -274,9 +278,12 @@ export class PiAcpSession {
   private readonly piCommand?: string
   private readonly autoTitleEnabled: boolean
   private readonly titleProcessFactory: TitleProcessFactory
+  private readonly titleTimeoutMs: number
 
   private autoTitleStarted = false
   private titleManuallySet = false
+  private activeTitleProc: PiRpcProcess | null = null
+  private disposed = false
 
   // Used to map abort semantics to ACP stopReason.
   // Applies to the currently running turn.
@@ -315,6 +322,8 @@ export class PiAcpSession {
     fileCommands?: FileSlashCommand[]
     piCommand?: string
     autoTitleEnabled?: boolean
+    hasExistingTitle?: boolean
+    titleTimeoutMs?: number
     titleProcessFactory?: TitleProcessFactory
   }) {
     this.sessionId = opts.sessionId
@@ -325,6 +334,8 @@ export class PiAcpSession {
     this.fileCommands = opts.fileCommands ?? []
     this.piCommand = opts.piCommand
     this.autoTitleEnabled = opts.autoTitleEnabled ?? process.env.PI_ACP_AUTO_TITLE !== 'false'
+    this.autoTitleStarted = opts.hasExistingTitle ?? false
+    this.titleTimeoutMs = opts.titleTimeoutMs ?? DEFAULT_TITLE_TIMEOUT_MS
     this.titleProcessFactory = opts.titleProcessFactory ?? (params => PiRpcProcess.spawn(params))
 
     this.proc.onEvent(ev => this.handlePiEvent(ev))
@@ -351,6 +362,8 @@ export class PiAcpSession {
   }
 
   async prompt(message: string, images: unknown[] = []): Promise<StopReason> {
+    if (this.disposed) throw RequestError.invalidParams(`Session is closed: ${this.sessionId}`)
+
     this.maybeStartAutoTitle(message)
 
     // pi RPC mode disables slash command expansion, so we do it here.
@@ -416,8 +429,15 @@ export class PiAcpSession {
     return this.cancelRequested
   }
 
+  dispose(): void {
+    this.disposed = true
+    this.activeTitleProc?.dispose()
+    this.activeTitleProc = null
+    this.proc.dispose?.()
+  }
+
   maybeStartAutoTitle(firstPrompt: string): void {
-    if (!this.autoTitleEnabled || this.autoTitleStarted || this.titleManuallySet) return
+    if (this.disposed || !this.autoTitleEnabled || this.autoTitleStarted || this.titleManuallySet) return
     if (!shouldAutoTitlePrompt(firstPrompt)) return
 
     this.autoTitleStarted = true
@@ -446,18 +466,27 @@ export class PiAcpSession {
 
     try {
       titleProc = await this.titleProcessFactory({ cwd: this.cwd, piCommand: this.piCommand })
-      const titleDone = waitForAgentEnd(titleProc)
-      await titleProc.prompt(buildTitlePrompt(firstPrompt))
-      await titleDone
+      if (this.disposed) return
+      this.activeTitleProc = titleProc
+      const titleDone = waitForAgentEnd(titleProc, this.titleTimeoutMs)
+      try {
+        await titleProc.prompt(buildTitlePrompt(firstPrompt))
+        await titleDone.promise
+      } catch (e) {
+        titleDone.cancel()
+        throw e
+      }
 
+      if (this.disposed) return
       title = sanitizeGeneratedTitle(extractLastAssistantText(await titleProc.getMessages()))
     } catch {
       title = fallbackTitleFromPrompt(firstPrompt)
     } finally {
-      titleProc?.dispose()
+      if (!this.disposed) titleProc?.dispose()
+      if (this.activeTitleProc === titleProc) this.activeTitleProc = null
     }
 
-    if (!title || this.titleManuallySet) return
+    if (!title || this.disposed || this.titleManuallySet) return
 
     await this.proc.setSessionName(title)
 
@@ -1066,14 +1095,31 @@ function optionIndex(optionId: string): number | null {
   return Number.isSafeInteger(index) && index >= 0 && String(index) === rawIndex ? index : null
 }
 
-function waitForAgentEnd(proc: PiRpcProcess): Promise<void> {
-  return new Promise(resolve => {
-    const off = proc.onEvent(ev => {
+function waitForAgentEnd(proc: PiRpcProcess, timeoutMs: number): { promise: Promise<void>; cancel: () => void } {
+  let off: (() => void) | null = null
+  let timer: NodeJS.Timeout | null = null
+
+  const cleanup = () => {
+    if (timer) clearTimeout(timer)
+    timer = null
+    off?.()
+    off = null
+  }
+
+  const promise = new Promise<void>((resolve, reject) => {
+    timer = setTimeout(() => {
+      cleanup()
+      reject(new Error('title worker timed out'))
+    }, timeoutMs)
+
+    off = proc.onEvent(ev => {
       if (String((ev as any).type ?? '') !== 'agent_end') return
-      off()
+      cleanup()
       resolve()
     })
   })
+
+  return { promise, cancel: cleanup }
 }
 
 function extractLastAssistantText(messages: unknown): string {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -27,6 +27,9 @@ import {
   isBashTool
 } from './translate/bash.js'
 import { toolResultToText } from './translate/pi-tools.js'
+import { buildTitlePrompt, fallbackTitleFromPrompt, sanitizeGeneratedTitle, shouldAutoTitlePrompt } from './title.js'
+
+type TitleProcessFactory = (params: { cwd: string; piCommand?: string }) => Promise<PiRpcProcess>
 
 type SessionCreateParams = {
   cwd: string
@@ -220,7 +223,8 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      piCommand: params.piCommand
     })
 
     this.sessions.set(sessionId, session)
@@ -247,7 +251,8 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc: params.proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      piCommand: params.piCommand
     })
 
     this.sessions.set(sessionId, session)
@@ -266,6 +271,12 @@ export class PiAcpSession {
   readonly proc: PiRpcProcess
   private readonly conn: AgentSideConnection
   private readonly fileCommands: FileSlashCommand[]
+  private readonly piCommand?: string
+  private readonly autoTitleEnabled: boolean
+  private readonly titleProcessFactory: TitleProcessFactory
+
+  private autoTitleStarted = false
+  private titleManuallySet = false
 
   // Used to map abort semantics to ACP stopReason.
   // Applies to the currently running turn.
@@ -302,6 +313,9 @@ export class PiAcpSession {
     proc: PiRpcProcess
     conn: AgentSideConnection
     fileCommands?: FileSlashCommand[]
+    piCommand?: string
+    autoTitleEnabled?: boolean
+    titleProcessFactory?: TitleProcessFactory
   }) {
     this.sessionId = opts.sessionId
     this.cwd = opts.cwd
@@ -309,6 +323,9 @@ export class PiAcpSession {
     this.proc = opts.proc
     this.conn = opts.conn
     this.fileCommands = opts.fileCommands ?? []
+    this.piCommand = opts.piCommand
+    this.autoTitleEnabled = opts.autoTitleEnabled ?? process.env.PI_ACP_AUTO_TITLE !== 'false'
+    this.titleProcessFactory = opts.titleProcessFactory ?? (params => PiRpcProcess.spawn(params))
 
     this.proc.onEvent(ev => this.handlePiEvent(ev))
   }
@@ -334,6 +351,8 @@ export class PiAcpSession {
   }
 
   async prompt(message: string, images: unknown[] = []): Promise<StopReason> {
+    this.maybeStartAutoTitle(message)
+
     // pi RPC mode disables slash command expansion, so we do it here.
     const expandedMessage = expandSlashCommand(message, this.fileCommands)
 
@@ -395,6 +414,58 @@ export class PiAcpSession {
 
   wasCancelRequested(): boolean {
     return this.cancelRequested
+  }
+
+  maybeStartAutoTitle(firstPrompt: string): void {
+    if (!this.autoTitleEnabled || this.autoTitleStarted || this.titleManuallySet) return
+    if (!shouldAutoTitlePrompt(firstPrompt)) return
+
+    this.autoTitleStarted = true
+
+    void this.generateAndSetTitle(firstPrompt).catch(() => {
+      // Best effort only. Auto-title must never fail the user's prompt.
+    })
+  }
+
+  async setManualTitle(name: string): Promise<void> {
+    this.titleManuallySet = true
+    this.autoTitleStarted = true
+
+    await this.proc.setSessionName(name)
+
+    this.emit({
+      sessionUpdate: 'session_info_update',
+      title: name,
+      updatedAt: new Date().toISOString()
+    })
+  }
+
+  private async generateAndSetTitle(firstPrompt: string): Promise<void> {
+    let title = ''
+    let titleProc: PiRpcProcess | null = null
+
+    try {
+      titleProc = await this.titleProcessFactory({ cwd: this.cwd, piCommand: this.piCommand })
+      const titleDone = waitForAgentEnd(titleProc)
+      await titleProc.prompt(buildTitlePrompt(firstPrompt))
+      await titleDone
+
+      title = sanitizeGeneratedTitle(extractLastAssistantText(await titleProc.getMessages()))
+    } catch {
+      title = fallbackTitleFromPrompt(firstPrompt)
+    } finally {
+      titleProc?.dispose()
+    }
+
+    if (!title || this.titleManuallySet) return
+
+    await this.proc.setSessionName(title)
+
+    this.emit({
+      sessionUpdate: 'session_info_update',
+      title,
+      updatedAt: new Date().toISOString()
+    })
   }
 
   private emit(update: SessionUpdate): void {
@@ -993,6 +1064,44 @@ function optionIndex(optionId: string): number | null {
 
   const index = Number(rawIndex)
   return Number.isSafeInteger(index) && index >= 0 && String(index) === rawIndex ? index : null
+}
+
+function waitForAgentEnd(proc: PiRpcProcess): Promise<void> {
+  return new Promise(resolve => {
+    const off = proc.onEvent(ev => {
+      if (String((ev as any).type ?? '') !== 'agent_end') return
+      off()
+      resolve()
+    })
+  })
+}
+
+function extractLastAssistantText(messages: unknown): string {
+  const list = Array.isArray(messages)
+    ? messages
+    : Array.isArray((messages as any)?.messages)
+      ? (messages as any).messages
+      : []
+
+  for (const message of [...list].reverse()) {
+    const role = String((message as any)?.role ?? '')
+    if (role && role !== 'assistant') continue
+
+    const content = (message as any)?.content ?? (message as any)?.message
+    if (typeof content === 'string') return content
+
+    if (Array.isArray(content)) {
+      return content
+        .map(part => {
+          if (typeof part === 'string') return part
+          if (typeof (part as any)?.text === 'string') return (part as any).text
+          return ''
+        })
+        .join('')
+    }
+  }
+
+  return ''
 }
 
 function formatAutoRetryMessage(ev: PiRpcEvent): string {

--- a/src/acp/title.ts
+++ b/src/acp/title.ts
@@ -1,0 +1,43 @@
+export function buildTitlePrompt(firstPrompt: string): string {
+  return [
+    'Generate a concise title for this coding-agent thread.',
+    '',
+    'Rules:',
+    '- Return only the title.',
+    '- Use 3 to 7 words.',
+    '- No markdown.',
+    '- No surrounding quotes.',
+    '- No trailing punctuation.',
+    '- Prefer specific nouns and verbs from the request.',
+    '',
+    "User's first prompt:",
+    firstPrompt
+  ].join('\n')
+}
+
+export function sanitizeGeneratedTitle(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/[.!?。]+$/g, '')
+    .slice(0, 80)
+    .trim()
+}
+
+export function fallbackTitleFromPrompt(prompt: string): string {
+  return prompt
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/[.!?。]+$/g, '')
+    .split(' ')
+    .slice(0, 8)
+    .join(' ')
+    .slice(0, 80)
+    .trim()
+}
+
+export function shouldAutoTitlePrompt(message: string): boolean {
+  const trimmed = message.trim()
+  return trimmed.length > 0 && !trimmed.startsWith('/')
+}

--- a/test/component/session-auto-title.test.ts
+++ b/test/component/session-auto-title.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { PiAcpSession } from '../../src/acp/session.js'
 import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
 
-function makeSession(opts: { titleProc?: FakePiRpcProcess; autoTitleEnabled?: boolean } = {}) {
+function makeSession(opts: { titleProc?: FakePiRpcProcess; autoTitleEnabled?: boolean; hasExistingTitle?: boolean; titleTimeoutMs?: number } = {}) {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
   const titleProc = opts.titleProc ?? new FakePiRpcProcess()
@@ -20,6 +20,8 @@ function makeSession(opts: { titleProc?: FakePiRpcProcess; autoTitleEnabled?: bo
     conn: asAgentConn(conn),
     fileCommands: [],
     autoTitleEnabled: opts.autoTitleEnabled,
+    hasExistingTitle: opts.hasExistingTitle,
+    titleTimeoutMs: opts.titleTimeoutMs,
     titleProcessFactory: async () => titleProc as any
   })
 
@@ -94,4 +96,36 @@ test('PiAcpSession: falls back to prompt-derived title when worker fails', async
   await new Promise(r => setTimeout(r, 0))
 
   assert.deepEqual(proc.setSessionNameCalls, ['Please fix the login redirect loop in auth'])
+})
+
+test('PiAcpSession: existing session title disables auto-title', async () => {
+  const { session, titleProc, proc } = makeSession({ hasExistingTitle: true })
+
+  void session.prompt('Fix the login redirect loop')
+  await flushAutoTitle(titleProc)
+
+  assert.equal(titleProc.prompts.length, 0)
+  assert.deepEqual(proc.setSessionNameCalls, [])
+})
+
+test('PiAcpSession: disposes stuck title worker after timeout', async () => {
+  const { session, titleProc, proc } = makeSession({ titleTimeoutMs: 1 })
+
+  void session.prompt('Fix the login redirect loop')
+  await new Promise(r => setTimeout(r, 10))
+
+  assert.equal(titleProc.disposeCount, 1)
+  assert.deepEqual(proc.setSessionNameCalls, ['Fix the login redirect loop'])
+})
+
+test('PiAcpSession: dispose stops active title worker and prevents late title updates', async () => {
+  const { session, titleProc, proc } = makeSession()
+
+  void session.prompt('Fix the login redirect loop')
+  await new Promise(r => setTimeout(r, 0))
+  session.dispose()
+  await flushAutoTitle(titleProc)
+
+  assert.equal(titleProc.disposeCount, 1)
+  assert.deepEqual(proc.setSessionNameCalls, [])
 })

--- a/test/component/session-auto-title.test.ts
+++ b/test/component/session-auto-title.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+function makeSession(opts: { titleProc?: FakePiRpcProcess; autoTitleEnabled?: boolean } = {}) {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const titleProc = opts.titleProc ?? new FakePiRpcProcess()
+
+  titleProc.messages = {
+    messages: [{ role: 'assistant', content: [{ type: 'text', text: 'Fix Login Redirect Loop' }] }]
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: [],
+    autoTitleEnabled: opts.autoTitleEnabled,
+    titleProcessFactory: async () => titleProc as any
+  })
+
+  return { conn, proc, session, titleProc }
+}
+
+async function flushAutoTitle(titleProc: FakePiRpcProcess) {
+  await new Promise(r => setTimeout(r, 0))
+  titleProc.emit({ type: 'agent_end' })
+  await new Promise(r => setTimeout(r, 0))
+  await new Promise(r => setTimeout(r, 0))
+}
+
+test('PiAcpSession: auto-generates title from first regular prompt', async () => {
+  const { conn, proc, session, titleProc } = makeSession()
+
+  void session.prompt('Fix the login redirect loop')
+  await flushAutoTitle(titleProc)
+
+  assert.equal(titleProc.prompts.length, 1)
+  assert.match(titleProc.prompts[0]!.message, /Generate a concise title/)
+  assert.deepEqual(proc.setSessionNameCalls, ['Fix Login Redirect Loop'])
+  assert.equal(
+    conn.updates.some(update => (update.update as any).title === 'Fix Login Redirect Loop'),
+    true
+  )
+})
+
+test('PiAcpSession: does not auto-title slash commands', async () => {
+  const { session, titleProc, proc } = makeSession()
+
+  void session.prompt('/session')
+  await flushAutoTitle(titleProc)
+
+  assert.equal(titleProc.prompts.length, 0)
+  assert.deepEqual(proc.setSessionNameCalls, [])
+})
+
+test('PiAcpSession: starts auto-title only once', async () => {
+  const { session, titleProc } = makeSession()
+
+  void session.prompt('Fix the login redirect loop')
+  void session.prompt('And update the tests')
+  await flushAutoTitle(titleProc)
+
+  assert.equal(titleProc.prompts.length, 1)
+})
+
+test('PiAcpSession: manual title prevents auto-title overwrite', async () => {
+  const { session, titleProc, proc } = makeSession()
+
+  void session.prompt('Fix the login redirect loop')
+  await session.setManualTitle('Custom Thread Name')
+  await flushAutoTitle(titleProc)
+
+  assert.deepEqual(proc.setSessionNameCalls, ['Custom Thread Name'])
+})
+
+test('PiAcpSession: falls back to prompt-derived title when worker fails', async () => {
+  const { session, proc } = makeSession({
+    titleProc: {
+      prompt: async () => {
+        throw new Error('boom')
+      },
+      dispose: () => {},
+      onEvent: () => () => {}
+    } as any
+  })
+
+  void session.prompt('Please fix the login redirect loop in auth before release')
+  await new Promise(r => setTimeout(r, 0))
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.deepEqual(proc.setSessionNameCalls, ['Please fix the login redirect loop in auth'])
+})

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -29,6 +29,9 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   abortCount = 0
+  disposeCount = 0
+  readonly setSessionNameCalls: string[] = []
+  messages: any = { messages: [] }
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
     this.handlers.push(handler)
@@ -62,7 +65,15 @@ export class FakePiRpcProcess {
   }
 
   async getMessages(): Promise<any> {
-    return { messages: [] }
+    return this.messages
+  }
+
+  async setSessionName(name: string): Promise<void> {
+    this.setSessionNameCalls.push(name)
+  }
+
+  dispose(): void {
+    this.disposeCount += 1
   }
 }
 

--- a/test/unit/builtin-commands.test.ts
+++ b/test/unit/builtin-commands.test.ts
@@ -42,7 +42,18 @@ test('PiAcpAgent: /name sets session display name adapter-side', async () => {
   }
 
   const agent = new PiAcpAgent(asAgentConn(conn))
-  ;(agent as any).sessions = new FakeSessions({ sessionId: 's1', proc, fileCommands: [] }) as any
+  ;(agent as any).sessions = new FakeSessions({
+    sessionId: 's1',
+    proc,
+    fileCommands: [],
+    async setManualTitle(name: string) {
+      await proc.setSessionName(name)
+      await conn.sessionUpdate({
+        sessionId: 's1',
+        update: { sessionUpdate: 'session_info_update', title: name, updatedAt: new Date().toISOString() }
+      } as any)
+    }
+  }) as any
 
   const res = await agent.prompt({
     sessionId: 's1',

--- a/test/unit/session-close-lifecycle.test.ts
+++ b/test/unit/session-close-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+
+const oldOpenAiKey = process.env.OPENAI_API_KEY
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = 'test-key'
+})
+
+afterEach(() => {
+  if (oldOpenAiKey == null) delete process.env.OPENAI_API_KEY
+  else process.env.OPENAI_API_KEY = oldOpenAiKey
+})
+
+function fakeSession(sessionId: string) {
+  return {
+    sessionId,
+    cwd: process.cwd(),
+    setStartupInfo(_text: string) {},
+    sendStartupInfoIfPending() {},
+    proc: {
+      disposeCount: 0,
+      async getAvailableModels() {
+        return { models: [{ provider: 'test', id: 'model', name: 'model' }] }
+      },
+      async getState() {
+        return { sessionId, thinkingLevel: 'medium', model: { provider: 'test', id: 'model' } }
+      },
+      async getCommands() {
+        return { commands: [] }
+      },
+      dispose() {
+        this.disposeCount += 1
+      }
+    }
+  }
+}
+
+test('PiAcpAgent: advertises stable session close capability', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()), {} as any)
+  const res = await agent.initialize({ protocolVersion: 1 } as any)
+
+  assert.ok(res.agentCapabilities)
+  assert.deepEqual((res.agentCapabilities.sessionCapabilities as any).close, {})
+})
+
+test('PiAcpAgent: creating a new session does not close other active sessions', async () => {
+  const sessions = [fakeSession('s1'), fakeSession('s2')]
+  const closeAllExceptCalls: string[] = []
+
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()), {} as any)
+  ;(agent as any).sessions = {
+    async create() {
+      const session = sessions.shift()
+      assert.ok(session)
+      return session
+    },
+    closeAllExcept(sessionId: string) {
+      closeAllExceptCalls.push(sessionId)
+    }
+  }
+
+  await agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any)
+  await agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any)
+
+  assert.deepEqual(closeAllExceptCalls, [])
+})
+
+test('PiAcpAgent: closeSession disposes only the requested active session', async () => {
+  const s1 = fakeSession('s1')
+  const s2 = fakeSession('s2')
+  const closed: string[] = []
+
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()), {} as any)
+  ;(agent as any).sessions = {
+    close(sessionId: string) {
+      closed.push(sessionId)
+      if (sessionId === 's1') s1.proc.dispose()
+      if (sessionId === 's2') s2.proc.dispose()
+    }
+  }
+
+  assert.equal(typeof (agent as any).closeSession, 'function')
+  await (agent as any).closeSession({ sessionId: 's1' })
+
+  assert.deepEqual(closed, ['s1'])
+  assert.equal(s1.proc.disposeCount, 1)
+  assert.equal(s2.proc.disposeCount, 0)
+})

--- a/test/unit/startup-info-env.test.ts
+++ b/test/unit/startup-info-env.test.ts
@@ -19,6 +19,7 @@ test('PiAcpAgent: quietStartup=true disables startup info generation/emission', 
   const { join } = await import('node:path')
   const dir = mkdtempSync(join(tmpdir(), 'pi-acp-quietstartup-'))
   writeFileSync(join(dir, 'settings.json'), JSON.stringify({ quietStartup: true }, null, 2), 'utf-8')
+  writeFileSync(join(dir, 'auth.json'), JSON.stringify({ test: true }, null, 2), 'utf-8')
   process.env.PI_CODING_AGENT_DIR = dir
 
   // Spy on setTimeout calls (agent schedules startup info + available commands)

--- a/test/unit/title.test.ts
+++ b/test/unit/title.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { fallbackTitleFromPrompt, sanitizeGeneratedTitle, shouldAutoTitlePrompt } from '../../src/acp/title.js'
+
+test('sanitizeGeneratedTitle removes quotes, whitespace, and trailing punctuation', () => {
+  assert.equal(sanitizeGeneratedTitle('  "Fix Login Redirect Loop."  '), 'Fix Login Redirect Loop')
+})
+
+test('sanitizeGeneratedTitle limits long titles', () => {
+  const title = sanitizeGeneratedTitle('a'.repeat(100))
+
+  assert.equal(title.length, 80)
+})
+
+test('fallbackTitleFromPrompt derives a short title from the prompt', () => {
+  assert.equal(
+    fallbackTitleFromPrompt('Please fix the login redirect loop in auth before release.'),
+    'Please fix the login redirect loop in auth'
+  )
+})
+
+test('shouldAutoTitlePrompt ignores empty prompts and slash commands', () => {
+  assert.equal(shouldAutoTitlePrompt(''), false)
+  assert.equal(shouldAutoTitlePrompt('   '), false)
+  assert.equal(shouldAutoTitlePrompt('/name Custom title'), false)
+  assert.equal(shouldAutoTitlePrompt('Fix the settings page'), true)
+})


### PR DESCRIPTION
## Why
I've been using `pi-acp` with Zed, but it had 2 issues:
- the title never updated
- it would break a session when I tried to spin up another one.

I've vibed these fixes and I've been using it successfully in my Zed.

I tried my best to figure out if this would break any other workflows.

## Summary
- Upgrade ACP SDK to 0.21.0 and advertise stable session close support
- Add best-effort automatic session titles from the first user prompt
- Preserve manual and existing history titles; add timeout/cleanup controls for background title workers

## Related PRs
Related to #19, which improves broader Zed integration with usage telemetry, metadata, structured diffs, and extension commands.

This PR is complementary and narrower:
- it adds generated first-prompt titles rather than placeholder/session-id titles
- it implements stable ACP `closeSession`
- it removes the old `closeAllExcept` behavior that could break another active session

Happy to rebase/stack this on #19 if maintainers prefer that direction.

## Verification
- npm test -- --runInBand
- npm run build
