### PR TITLE
fix: support updated pi edit results

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -54,11 +54,43 @@ function findUniqueLineNumber(text: string, needle: string): number | undefined 
   return line
 }
 
+function getToolPath(args: unknown): string | undefined {
+  const record = args as { path?: unknown; file_path?: unknown } | null | undefined
+  if (typeof record?.path === 'string') return record.path
+  if (typeof record?.file_path === 'string') return record.file_path
+  return undefined
+}
+
+// Match pi's current edit schema: { path, edits: [{ oldText, newText }] }, with
+// legacy top-level oldText/newText still accepted. Pi also normalizes stringified edits.
+// https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/tools/edit.ts
+function getEditOldTexts(args: unknown): string[] {
+  const record = args as { oldText?: unknown; edits?: unknown } | null | undefined
+  const oldTexts: string[] = []
+
+  if (typeof record?.oldText === 'string') oldTexts.push(record.oldText)
+
+  let edits = record?.edits
+  if (typeof edits === 'string') {
+    try {
+      edits = JSON.parse(edits) as unknown
+    } catch {
+      edits = undefined
+    }
+  }
+
+  if (Array.isArray(edits)) {
+    for (const edit of edits) {
+      const oldText = (edit as { oldText?: unknown } | null | undefined)?.oldText
+      if (typeof oldText === 'string') oldTexts.push(oldText)
+    }
+  }
+
+  return oldTexts
+}
+
 function toToolCallLocations(args: unknown, cwd: string, line?: number): ToolCallLocation[] | undefined {
-  const path =
-    typeof (args as { path?: unknown } | null | undefined)?.path === 'string'
-      ? (args as { path: string }).path
-      : undefined
+  const path = getToolPath(args)
   if (!path) return undefined
 
   const resolvedPath = isAbsolute(path) ? path : resolvePath(cwd, path)
@@ -483,15 +515,17 @@ export class PiAcpSession {
 
         // Capture pre-edit file contents so we can emit a structured ACP diff on completion.
         if (toolName === 'edit') {
-          const p = typeof args?.path === 'string' ? args.path : undefined
+          const p = getToolPath(args)
           if (p) {
             try {
               const abs = isAbsolute(p) ? p : resolvePath(this.cwd, p)
               const oldText = readFileSync(abs, 'utf8')
               this.editSnapshots.set(toolCallId, { path: p, oldText })
 
-              const needle = typeof args?.oldText === 'string' ? args.oldText : ''
-              line = findUniqueLineNumber(oldText, needle)
+              for (const needle of getEditOldTexts(args)) {
+                line = findUniqueLineNumber(oldText, needle)
+                if (typeof line === 'number') break
+              }
             } catch {
               // Ignore snapshot failures; we'll fall back to plain text output.
             }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -64,11 +64,40 @@ function getToolPath(args: unknown): string | undefined {
 // Match pi's current edit schema: { path, edits: [{ oldText, newText }] }, with
 // legacy top-level oldText/newText still accepted. Pi also normalizes stringified edits.
 // https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/src/core/tools/edit.ts
+function getParsedEdits(args: unknown): Array<{ oldText: string; newText: string }> {
+  const record = args as { oldText?: unknown; newText?: unknown; edits?: unknown } | null | undefined
+  const parsed: Array<{ oldText: string; newText: string }> = []
+
+  if (typeof record?.oldText === 'string' && typeof record?.newText === 'string') {
+    parsed.push({ oldText: record.oldText, newText: record.newText })
+  }
+
+  let edits = record?.edits
+  if (typeof edits === 'string') {
+    try {
+      edits = JSON.parse(edits) as unknown
+    } catch {
+      edits = undefined
+    }
+  }
+
+  if (Array.isArray(edits)) {
+    for (const edit of edits) {
+      const item = edit as { oldText?: unknown; newText?: unknown } | null | undefined
+      if (typeof item?.oldText === 'string' && typeof item?.newText === 'string') {
+        parsed.push({ oldText: item.oldText, newText: item.newText })
+      }
+    }
+  }
+
+  return parsed
+}
+
 function getEditOldTexts(args: unknown): string[] {
   const record = args as { oldText?: unknown; edits?: unknown } | null | undefined
-  const oldTexts: string[] = []
+  const oldTexts = getParsedEdits(args).map(edit => edit.oldText)
 
-  if (typeof record?.oldText === 'string') oldTexts.push(record.oldText)
+  if (typeof record?.oldText === 'string' && !oldTexts.includes(record.oldText)) oldTexts.push(record.oldText)
 
   let edits = record?.edits
   if (typeof edits === 'string') {
@@ -82,7 +111,7 @@ function getEditOldTexts(args: unknown): string[] {
   if (Array.isArray(edits)) {
     for (const edit of edits) {
       const oldText = (edit as { oldText?: unknown } | null | undefined)?.oldText
-      if (typeof oldText === 'string') oldTexts.push(oldText)
+      if (typeof oldText === 'string' && !oldTexts.includes(oldText)) oldTexts.push(oldText)
     }
   }
 
@@ -234,10 +263,11 @@ export class PiAcpSession {
   // The overall agent loop completes when `agent_end` is emitted.
   private inAgentLoop = false
 
-  // For ACP diff support: capture file contents before edits, then emit ToolCallContent {type:"diff"}.
-  // This is due to pi sending diff as a string as opposed to ACP expected diff format.
-  // Compatible format may need to be implemented in pi in the future.
-  private editSnapshots = new Map<string, { path: string; oldText: string }>()
+  // For ACP diff support: capture file contents before edit/write mutations,
+  // then emit ToolCallContent {type:"diff"}. Compatible structured edit/write
+  // events may need to be implemented in pi in the future.
+  private fileSnapshots = new Map<string, { path: string; oldText: string | null }>()
+  private fileMutationToolCallIds = new Set<string>()
 
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
@@ -513,21 +543,27 @@ export class PiAcpSession {
         const args = (ev as any).args
         let line: number | undefined
 
-        // Capture pre-edit file contents so we can emit a structured ACP diff on completion.
-        if (toolName === 'edit') {
+        // Capture pre-mutation file contents so we can emit a structured ACP diff.
+        const isFileMutation = toolName === 'edit' || toolName === 'write'
+        let snapshotOldText: string | null | undefined
+        if (isFileMutation) {
+          this.fileMutationToolCallIds.add(toolCallId)
           const p = getToolPath(args)
           if (p) {
             try {
               const abs = isAbsolute(p) ? p : resolvePath(this.cwd, p)
-              const oldText = readFileSync(abs, 'utf8')
-              this.editSnapshots.set(toolCallId, { path: p, oldText })
+              snapshotOldText = readFileSync(abs, 'utf8')
+              this.fileSnapshots.set(toolCallId, { path: p, oldText: snapshotOldText })
 
-              for (const needle of getEditOldTexts(args)) {
-                line = findUniqueLineNumber(oldText, needle)
-                if (typeof line === 'number') break
+              if (toolName === 'edit') {
+                for (const needle of getEditOldTexts(args)) {
+                  line = findUniqueLineNumber(snapshotOldText, needle)
+                  if (typeof line === 'number') break
+                }
               }
             } catch {
-              // Ignore snapshot failures; we'll fall back to plain text output.
+              snapshotOldText = null
+              this.fileSnapshots.set(toolCallId, { path: p, oldText: null })
             }
           }
         }
@@ -565,7 +601,7 @@ export class PiAcpSession {
         if (!toolCallId) break
 
         const partial = (ev as any).partialResult
-        const text = toolResultToText(partial)
+        const text = this.fileMutationToolCallIds.has(toolCallId) ? '' : toolResultToText(partial)
 
         this.emit({
           sessionUpdate: 'tool_call_update',
@@ -574,7 +610,7 @@ export class PiAcpSession {
           content: text
             ? ([{ type: 'content', content: { type: 'text', text } }] satisfies ToolCallContent[])
             : undefined,
-          rawOutput: partial
+          ...(this.fileMutationToolCallIds.has(toolCallId) ? {} : { rawOutput: partial })
         })
         break
       }
@@ -587,24 +623,23 @@ export class PiAcpSession {
         const isError = Boolean((ev as any).isError)
         const text = toolResultToText(result)
 
-        // If this was an edit and we captured a snapshot, emit a structured ACP diff.
-        // This enables clients like Zed to render an actual diff UI.
-        const snapshot = this.editSnapshots.get(toolCallId)
+        const snapshot = this.fileSnapshots.get(toolCallId)
         let content: ToolCallContent[] | undefined
+        let hasStructuredDiff = false
 
         if (!isError && snapshot) {
           try {
             const abs = isAbsolute(snapshot.path) ? snapshot.path : resolvePath(this.cwd, snapshot.path)
             const newText = readFileSync(abs, 'utf8')
-            if (newText !== snapshot.oldText) {
+            if (snapshot.oldText === null || newText !== snapshot.oldText) {
+              hasStructuredDiff = true
               content = [
                 {
                   type: 'diff',
                   path: snapshot.path,
                   oldText: snapshot.oldText,
                   newText
-                },
-                ...(text ? ([{ type: 'content', content: { type: 'text', text } }] as ToolCallContent[]) : [])
+                }
               ]
             }
           } catch {
@@ -612,8 +647,7 @@ export class PiAcpSession {
           }
         }
 
-        // Fallback: just text content.
-        if (!content && text) {
+        if (!content && !hasStructuredDiff && text) {
           content = [{ type: 'content', content: { type: 'text', text } }] satisfies ToolCallContent[]
         }
 
@@ -622,11 +656,12 @@ export class PiAcpSession {
           toolCallId,
           status: isError ? 'failed' : 'completed',
           content,
-          rawOutput: result
+          ...(hasStructuredDiff ? {} : { rawOutput: result })
         })
 
         this.currentToolCalls.delete(toolCallId)
-        this.editSnapshots.delete(toolCallId)
+        this.fileSnapshots.delete(toolCallId)
+        this.fileMutationToolCallIds.delete(toolCallId)
         break
       }
 

--- a/src/acp/translate/pi-tools.ts
+++ b/src/acp/translate/pi-tools.ts
@@ -1,6 +1,14 @@
 export function toolResultToText(result: unknown): string {
   if (!result) return ''
 
+  const details = (result as any)?.details
+
+  // pi's edit tool returns a terse success message in content and the full unified diff in details.diff.
+  const diff = details?.diff
+  if (typeof diff === 'string' && diff.trim()) {
+    return diff
+  }
+
   // pi tool results generally look like: { content: [{type:"text", text:"..."}], details: {...} }
   const content = (result as any).content
   if (Array.isArray(content)) {
@@ -8,14 +16,6 @@ export function toolResultToText(result: unknown): string {
       .map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : ''))
       .filter(Boolean)
     if (texts.length) return texts.join('')
-  }
-
-  const details = (result as any)?.details
-
-  // Some pi tools return a unified diff in `details.diff`.
-  const diff = details?.diff
-  if (typeof diff === 'string' && diff.trim()) {
-    return diff
   }
 
   // The bash tool frequently returns stdout/stderr in `details` rather than content blocks.

--- a/test/component/session-diff.test.ts
+++ b/test/component/session-diff.test.ts
@@ -7,30 +7,41 @@ import { join } from 'node:path'
 import { PiAcpSession } from '../../src/acp/session.js'
 import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
 
-test('PiAcpSession: emits ACP diff content for edit tool when file changes', async () => {
+function createSession(cwd: string) {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
-  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
-  mkdirSync(dir, { recursive: true })
-  const filePath = join(dir, 'a.txt')
-  writeFileSync(filePath, 'before\n', 'utf8')
-
   new PiAcpSession({
     sessionId: 's1',
-    cwd: dir,
+    cwd,
     mcpServers: [],
     proc: proc as any,
     conn: asAgentConn(conn),
     fileCommands: []
   })
 
-  // Start edit -> snapshot should be taken
+  return { conn, proc }
+}
+
+function completedToolUpdate(conn: FakeAgentSideConnection, toolCallId = 't1') {
+  return conn.updates.find(
+    u =>
+      (u.update as any).toolCallId === toolCallId &&
+      u.update.sessionUpdate === 'tool_call_update' &&
+      (u.update as any).status === 'completed'
+  )
+}
+
+test('PiAcpSession: emits ACP diff content for edit tool from actual before/after file contents', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'a.txt')
+  writeFileSync(filePath, 'before\n', 'utf8')
+
+  const { conn, proc } = createSession(dir)
+
   proc.emit({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'edit', args: { path: 'a.txt' } })
-
-  // Simulate file being edited by pi
   writeFileSync(filePath, 'after\n', 'utf8')
-
   proc.emit({
     type: 'tool_execution_end',
     toolCallId: 't1',
@@ -40,15 +51,164 @@ test('PiAcpSession: emits ACP diff content for edit tool when file changes', asy
 
   await new Promise(r => setTimeout(r, 0))
 
-  const end = conn.updates.find(u => (u.update as any).toolCallId === 't1' && u.update.sessionUpdate === 'tool_call_update')
-  assert.ok(end, 'expected tool_call_update for edit completion')
+  const end = completedToolUpdate(conn)
+  assert.ok(end, 'expected completed tool_call_update')
 
-  const content = (end!.update as any).content as any[]
+  const content = (end.update as any).content as any[]
   assert.ok(Array.isArray(content), 'expected content array')
   const diff = content.find(c => c.type === 'diff')
   assert.ok(diff, 'expected diff content item')
-
   assert.equal(diff.path, 'a.txt')
   assert.equal(diff.oldText, 'before\n')
   assert.equal(diff.newText, 'after\n')
+  assert.equal((end.update as any).rawOutput, undefined, 'expected raw output to be suppressed when diff is emitted')
+})
+
+test('PiAcpSession: does not turn requested edit args into finalized ACP diffs at tool start', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'a.txt')
+  writeFileSync(filePath, 'before\n', 'utf8')
+
+  const { conn, proc } = createSession(dir)
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'edit',
+    args: { path: 'a.txt', edits: [{ oldText: 'before', newText: 'after' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const start = conn.updates.find(u => (u.update as any).toolCallId === 't1' && u.update.sessionUpdate === 'tool_call')
+  assert.ok(start, 'expected tool_call for edit start')
+  assert.equal((start.update as any).content, undefined, 'expected no start-time diff from requested edit args')
+
+  writeFileSync(filePath, 'after\n', 'utf8')
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 't1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'ok' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = completedToolUpdate(conn)
+  assert.ok(end, 'expected completed tool_call_update')
+  const diff = (end.update as any).content?.find((c: any) => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item')
+  assert.equal(diff.oldText, 'before\n')
+  assert.equal(diff.newText, 'after\n')
+})
+
+test('PiAcpSession: edit diff uses realized fuzzy-match file contents instead of requested args', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'fuzzy.txt')
+  writeFileSync(filePath, 'FULLWIDTH: ＡＢＣ１２３\n', 'utf8')
+
+  const { conn, proc } = createSession(dir)
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'edit',
+    args: {
+      path: 'fuzzy.txt',
+      edits: [{ oldText: 'FULLWIDTH: ABC123', newText: 'FULLWIDTH: ascii replacement' }]
+    }
+  })
+
+  writeFileSync(filePath, 'FULLWIDTH: ascii replacement\n', 'utf8')
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 't1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'Successfully replaced 1 block(s) in fuzzy.txt.' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = completedToolUpdate(conn)
+  assert.ok(end, 'expected completed tool_call_update')
+  const diff = (end.update as any).content?.find((c: any) => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item')
+  assert.equal(diff.oldText, 'FULLWIDTH: ＡＢＣ１２３\n')
+  assert.equal(diff.newText, 'FULLWIDTH: ascii replacement\n')
+})
+
+test('PiAcpSession: emits write diff content from actual before/after file contents on completion', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'a.txt')
+  writeFileSync(filePath, 'before\n', 'utf8')
+
+  const { conn, proc } = createSession(dir)
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'write',
+    args: { path: 'a.txt', content: 'after\n' }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const start = conn.updates.find(u => (u.update as any).toolCallId === 't1' && u.update.sessionUpdate === 'tool_call')
+  assert.ok(start, 'expected tool_call for write start')
+  assert.equal((start.update as any).content, undefined, 'expected no start-time diff for write')
+
+  writeFileSync(filePath, 'after\n', 'utf8')
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 't1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'Successfully wrote 6 bytes to a.txt' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = completedToolUpdate(conn)
+  assert.ok(end, 'expected completed tool_call_update')
+  const diff = (end.update as any).content?.find((c: any) => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item')
+  assert.equal(diff.path, 'a.txt')
+  assert.equal(diff.oldText, 'before\n')
+  assert.equal(diff.newText, 'after\n')
+  assert.equal((end.update as any).rawOutput, undefined, 'expected raw output to be suppressed when diff is emitted')
+})
+
+test('PiAcpSession: emits write diff content for new files on completion', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-diff-'))
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, 'new.txt')
+
+  const { conn, proc } = createSession(dir)
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'write',
+    args: { path: 'new.txt', content: 'created\n' }
+  })
+
+  writeFileSync(filePath, 'created\n', 'utf8')
+  proc.emit({
+    type: 'tool_execution_end',
+    toolCallId: 't1',
+    isError: false,
+    result: { content: [{ type: 'text', text: 'Successfully wrote 8 bytes to new.txt' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  const end = completedToolUpdate(conn)
+  assert.ok(end, 'expected completed tool_call_update')
+  const diff = (end.update as any).content?.find((c: any) => c.type === 'diff')
+  assert.ok(diff, 'expected diff content item')
+  assert.equal(diff.path, 'new.txt')
+  assert.equal(diff.oldText, null)
+  assert.equal(diff.newText, 'created\n')
 })

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -400,6 +400,70 @@ test('PiAcpSession: emits edit tool line when oldText matches uniquely', async (
   assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: filePath, line: 3 }])
 })
 
+test('PiAcpSession: emits edit tool line from edits array when oldText matches uniquely', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-lines-edits-'))
+  const filePath = join(cwd, 'a.txt')
+
+  mkdirSync(cwd, { recursive: true })
+  writeFileSync(filePath, 'one\ntwo\nneedle\nthree\n', 'utf8')
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd,
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'edit',
+    args: { path: 'a.txt', edits: [{ oldText: 'needle', newText: 'replacement' }] }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.equal(conn.updates[0]!.update.sessionUpdate, 'tool_call')
+  assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: filePath, line: 3 }])
+})
+
+test('PiAcpSession: emits edit tool line from stringified edits array', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-lines-edits-string-'))
+  const filePath = join(cwd, 'a.txt')
+
+  mkdirSync(cwd, { recursive: true })
+  writeFileSync(filePath, 'one\ntwo\nneedle\nthree\n', 'utf8')
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd,
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'tool_execution_start',
+    toolCallId: 't1',
+    toolName: 'edit',
+    args: { path: 'a.txt', edits: JSON.stringify([{ oldText: 'needle', newText: 'replacement' }]) }
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.equal(conn.updates[0]!.update.sessionUpdate, 'tool_call')
+  assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: filePath, line: 3 }])
+})
+
 test('PiAcpSession: omits edit tool line when oldText matches multiple times', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/unit/pi-tools.test.ts
+++ b/test/unit/pi-tools.test.ts
@@ -13,7 +13,10 @@ test('toolResultToText: extracts text from content blocks', () => {
 })
 
 test('toolResultToText: prefers details.diff when present', () => {
-  const text = toolResultToText({ details: { diff: '--- a\n+++ b\n' } })
+  const text = toolResultToText({
+    content: [{ type: 'text', text: 'Successfully replaced 2 block(s) in a.txt.' }],
+    details: { diff: '--- a\n+++ b\n' }
+  })
   assert.equal(text, '--- a\n+++ b\n')
 })
 


### PR DESCRIPTION
Hello!

This PR is to add support for pi's updated edit tool schema `{ path, edits: [{ oldText, newText }] }` so that edits show up in Zed (where I'm testing). Currently I see lines like `"Successfully replaced 6 block(s) in scripts/capture-fixtures.mjs."` under edit tool actions.

## Testing
With this change we now get edits in Zed, which I used to tweak the ouput of this generated code :D

<img width="850" height="1181" alt="Screenshot 2026-05-06 at 13 24 17" src="https://github.com/user-attachments/assets/0ede713a-e1de-4dfb-8db2-52a400b6210e" />
