### PR TITLE
feat: add PI_ACP_SKIP_PI_AUTH env var to bypass pre-spawn auth check

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Point your ACP client to the built `dist/index.js`:
 - Default: unset/any other value means `false`.
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
 
+- `PI_ACP_SKIP_PI_AUTH=true` bypasses the pre-spawn auth probe. Use this when relying on pi custom/dynamic providers (e.g. LMStudio) whose models only register after pi starts. With this set, `pi-acp` will spawn pi even if no static API key is detected; if pi truly has no model available, it will still surface an auth-required error at runtime.
+- Default: unset/any other value means the auth check runs normally.
+
 You can add the environment variable in the Zed settings with:
 
 ```json

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -159,7 +159,9 @@ export class PiAcpAgent implements ACPAgent {
     // IMPORTANT: pi exits immediately in --mode rpc if no model is available (no auth configured).
     // So we must detect that situation without spawning pi, and return AUTH_REQUIRED so clients
     // (e.g. Zed) can show the Authenticate banner and launch a terminal login.
-    if (!hasAnyPiAuthConfigured()) {
+    // PI_ACP_SKIP_PI_AUTH is an opt-out for users on dynamic/custom providers (e.g. LMStudio)
+    // whose models only register after pi spawns, so the static check would falsely reject them.
+    if (process.env.PI_ACP_SKIP_PI_AUTH !== 'true' && !hasAnyPiAuthConfigured()) {
       throw RequestError.authRequired(
         { authMethods: getAuthMethods() },
         'Configure an API key or log in with an OAuth provider.'

--- a/test/unit/pi-skip-auth-flag.test.ts
+++ b/test/unit/pi-skip-auth-flag.test.ts
@@ -1,0 +1,112 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+
+const SPAWN_SENTINEL = 'spawn-reached'
+
+class SpawnSentinelSessions {
+  async create() {
+    throw new Error(SPAWN_SENTINEL)
+  }
+}
+
+class FailIfSpawnedSessions {
+  async create() {
+    throw new Error('pi should not be spawned when no auth is configured and skip flag is unset')
+  }
+}
+
+const PROVIDER_ENV_KEYS = [
+  'OPENAI_API_KEY', 'AZURE_OPENAI_API_KEY', 'GEMINI_API_KEY', 'GROQ_API_KEY',
+  'CEREBRAS_API_KEY', 'XAI_API_KEY', 'OPENROUTER_API_KEY', 'AI_GATEWAY_API_KEY',
+  'ZAI_API_KEY', 'MISTRAL_API_KEY', 'MINIMAX_API_KEY', 'MINIMAX_CN_API_KEY',
+  'HF_TOKEN', 'OPENCODE_API_KEY', 'KIMI_API_KEY',
+  'COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN',
+  'ANTHROPIC_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'
+]
+
+function setupEmptyAgentDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-skip-auth-'))
+  writeFileSync(join(dir, 'auth.json'), '{}', 'utf-8')
+  writeFileSync(join(dir, 'models.json'), '{}', 'utf-8')
+  return dir
+}
+
+function saveAndClearAuthEnv() {
+  const saved: Record<string, string | undefined> = {}
+  for (const k of PROVIDER_ENV_KEYS) {
+    saved[k] = process.env[k]
+    delete process.env[k]
+  }
+  saved.PI_CODING_AGENT_DIR = process.env.PI_CODING_AGENT_DIR
+  saved.PI_ACP_SKIP_PI_AUTH = process.env.PI_ACP_SKIP_PI_AUTH
+  return saved
+}
+
+function restoreEnv(saved: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v == null) delete process.env[k]
+    else process.env[k] = v
+  }
+}
+
+test('PI_ACP_SKIP_PI_AUTH unset: newSession still rejects with AUTH_REQUIRED when no auth configured', async () => {
+  const saved = saveAndClearAuthEnv()
+  delete process.env.PI_ACP_SKIP_PI_AUTH
+  process.env.PI_CODING_AGENT_DIR = setupEmptyAgentDir()
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = new FailIfSpawnedSessions() as any
+
+    await assert.rejects(
+      () => agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any),
+      (e: any) => e?.code === -32000
+    )
+  } finally {
+    restoreEnv(saved)
+  }
+})
+
+test("PI_ACP_SKIP_PI_AUTH='true': newSession bypasses auth gate and proceeds to spawn", async () => {
+  const saved = saveAndClearAuthEnv()
+  process.env.PI_ACP_SKIP_PI_AUTH = 'true'
+  process.env.PI_CODING_AGENT_DIR = setupEmptyAgentDir()
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = new SpawnSentinelSessions() as any
+
+    await assert.rejects(
+      () => agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any),
+      (e: any) => e?.message === SPAWN_SENTINEL && e?.code !== -32000
+    )
+  } finally {
+    restoreEnv(saved)
+  }
+})
+
+test("PI_ACP_SKIP_PI_AUTH='false': auth gate still runs (only 'true' opts out)", async () => {
+  const saved = saveAndClearAuthEnv()
+  process.env.PI_ACP_SKIP_PI_AUTH = 'false'
+  process.env.PI_CODING_AGENT_DIR = setupEmptyAgentDir()
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = new FailIfSpawnedSessions() as any
+
+    await assert.rejects(
+      () => agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any),
+      (e: any) => e?.code === -32000
+    )
+  } finally {
+    restoreEnv(saved)
+  }
+})


### PR DESCRIPTION
## Summary

- Adds a new `PI_ACP_SKIP_PI_AUTH=true` environment variable that bypasses the pre-spawn `hasAnyPiAuthConfigured()` probe in `newSession()`.
- Targets users on pi custom/dynamic providers (e.g. [pi-custom-provider-lmstudio](https://github.com/vampaz/pi-custom-provider-lmstudio)) whose models only register *after* pi spawns, causing the static auth check to falsely return `AUTH_REQUIRED`.
- The check stays on by default; only opt-in via the flag changes behavior. Runtime auth-required detection from pi's stderr is unaffected, so a truly misconfigured setup still surfaces the error.

Closes #15.

## Implementation

- `src/acp/agent.ts`: gate the existing `hasAnyPiAuthConfigured()` check behind `process.env.PI_ACP_SKIP_PI_AUTH !== 'true'`. Comment block extended with the rationale.
- `README.md`: documented under the existing Environment variables section, mirroring the `PI_ACP_ENABLE_EMBEDDED_CONTEXT` style.
- Parsing convention matches `PI_ACP_ENABLE_EMBEDDED_CONTEXT` (strict `=== 'true'`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test` — 3 new tests pass:
  - `PI_ACP_SKIP_PI_AUTH` unset → still rejects with AUTH_REQUIRED (`-32000`) when no auth configured
  - `PI_ACP_SKIP_PI_AUTH='true'` → bypasses gate and proceeds to spawn
  - `PI_ACP_SKIP_PI_AUTH='false'` → gate still runs (only `'true'` opts out)
- [ ] Manual smoke with a custom provider (LMStudio) confirming `pi-acp` reaches pi instead of returning AUTH_REQUIRED.

## Notes

One pre-existing test (`test/unit/startup-info-env.test.ts`) fails on a clean dev machine because it doesn't unset known provider env vars before exercising the auth gate; this PR does not change that behavior (the failure occurs on `main` as well).