### PR TITLE
fix: include project-level packages in startup info

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -1340,22 +1340,23 @@ function buildStartupInfo(opts: {
     // ignore
   }
 
-  // Also show npm packages from pi settings (best-effort)
-  try {
-    const settingsPath = join(process.env.HOME ?? '', '.pi', 'agent', 'settings.json')
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as any
-    const pkgs: string[] = Array.isArray(settings?.packages) ? settings.packages : []
-    for (const pkg of pkgs) {
-      const s = String(pkg)
-      if (s.startsWith('npm:')) {
-        // Render a two-line bullet structure using markdown indentation.
-        extItems.push(`${s}\n  - index.ts`)
-      } else {
-        extItems.push(s)
+  // Also show npm packages from pi settings (global + project)
+  const settingsPaths = [join(getAgentDir(), 'settings.json'), join(opts.cwd, '.pi', 'settings.json')]
+  for (const settingsPath of settingsPaths) {
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as any
+      const pkgs: string[] = Array.isArray(settings?.packages) ? settings.packages : []
+      for (const pkg of pkgs) {
+        const s = String(pkg)
+        if (s.startsWith('npm:')) {
+          extItems.push(`${s}\n  - index.ts`)
+        } else {
+          extItems.push(s)
+        }
       }
+    } catch {
+      // ignore
     }
-  } catch {
-    // ignore
   }
 
   addSection('Extensions', extItems)

--- a/test/unit/startup-info-project-packages.test.ts
+++ b/test/unit/startup-info-project-packages.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+
+class FakeSessions {
+  constructor(private readonly session: any) {}
+  async create(_params: any) {
+    return this.session
+  }
+  closeAllExcept() {}
+}
+
+test('PiAcpAgent: startup info includes project-level packages from .pi/settings.json', async () => {
+  const { mkdtempSync, writeFileSync, mkdirSync } = await import('node:fs')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+
+  const prevAgentDir = process.env.PI_CODING_AGENT_DIR
+
+  // Create a fake global agent dir (empty settings)
+  const agentDir = mkdtempSync(join(tmpdir(), 'pi-acp-global-'))
+  writeFileSync(join(agentDir, 'settings.json'), JSON.stringify({ packages: ['npm:global-ext'] }), 'utf-8')
+  process.env.PI_CODING_AGENT_DIR = agentDir
+
+  // Create a fake project dir with .pi/settings.json containing packages
+  const projectDir = mkdtempSync(join(tmpdir(), 'pi-acp-project-'))
+  const piDir = join(projectDir, '.pi')
+  mkdirSync(piDir)
+  writeFileSync(join(piDir, 'settings.json'), JSON.stringify({ packages: ['/path/to/local-extension'] }), 'utf-8')
+
+  const realSetTimeout = globalThis.setTimeout
+  ;(globalThis as any).setTimeout = (fn: unknown) => {
+    return 0 as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+
+    const session = {
+      sessionId: 's1',
+      cwd: projectDir,
+      proc: {
+        async getAvailableModels() {
+          return { models: [{ provider: 'test', id: 'model', name: 'model' }] }
+        },
+        async getState() {
+          return { thinkingLevel: 'medium', model: { provider: 'test', id: 'model' } }
+        },
+        async getCommands() {
+          return { commands: [] }
+        }
+      },
+      setStartupInfo(_text: string) {},
+      sendStartupInfoIfPending() {}
+    }
+
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = new FakeSessions(session) as any
+
+    const res = await agent.newSession({ cwd: projectDir, mcpServers: [] } as any)
+    const startupInfo: string = res?._meta?.piAcp?.startupInfo ?? ''
+
+    assert.ok(startupInfo.includes('npm:global-ext'), 'should include global package')
+    assert.ok(startupInfo.includes('/path/to/local-extension'), 'should include project package')
+  } finally {
+    ;(globalThis as any).setTimeout = realSetTimeout
+    if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR
+    else process.env.PI_CODING_AGENT_DIR = prevAgentDir
+  }
+})

--- a/test/unit/startup-info-project-packages.test.ts
+++ b/test/unit/startup-info-project-packages.test.ts
@@ -30,7 +30,7 @@ test('PiAcpAgent: startup info includes project-level packages from .pi/settings
   writeFileSync(join(piDir, 'settings.json'), JSON.stringify({ packages: ['/path/to/local-extension'] }), 'utf-8')
 
   const realSetTimeout = globalThis.setTimeout
-  ;(globalThis as any).setTimeout = (fn: unknown) => {
+  ;(globalThis as any).setTimeout = () => {
     return 0 as any
   }
 


### PR DESCRIPTION
## Summary

`buildStartupInfo` only read packages from the global settings (`~/.pi/agent/settings.json`), so project-specific extensions defined in `<cwd>/.pi/settings.json` were missing from the 'loaded extensions' list shown on session start in ACP clients (e.g. Zed).

## Changes

- Read packages from both global and project `.pi/settings.json` in `buildStartupInfo`
- Use `getAgentDir()` for the global settings path (respects `PI_CODING_AGENT_DIR` override)
- Added unit test verifying both global and project packages appear in startup info

## Testing

- Verified locally with Zed + arvore-hub project (project extensions now show in the loaded list)
- All 73 tests pass

Fixes #36