### PR TITLE
fix: auto-restore session after pi-acp restart (fixes #28)

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -110,6 +110,52 @@ export class PiAcpAgent implements ACPAgent {
   // Remember recent session cwd and use it as the default filter.
   private lastSessionCwd: string | null = null
 
+  /**
+   * Returns the session for the given ID, auto-restoring it from session-map.json
+   * if pi-acp was restarted and the in-memory map no longer holds the session.
+   *
+   * Fixes: https://github.com/svkozak/pi-acp/issues/28
+   */
+  private async autoRestoreSession(sessionId: string, mcpServers?: unknown[]) {
+    const existing = this.sessions.maybeGet(sessionId)
+    if (existing) return existing
+
+    const stored = this.store.get(sessionId)
+    if (!stored?.sessionFile) {
+      throw RequestError.invalidParams(`Unknown sessionId: ${sessionId}`)
+    }
+
+    let proc: PiRpcProcess
+    try {
+      proc = await PiRpcProcess.spawn({
+        cwd: stored.cwd,
+        sessionPath: stored.sessionFile,
+        piCommand: process.env.PI_ACP_PI_COMMAND,
+      })
+    } catch (err) {
+      throw RequestError.invalidParams(
+        `Unknown sessionId: ${sessionId} (failed to restore: ${err instanceof Error ? err.message : String(err)})`
+      )
+    }
+
+    const fileCommands = loadSlashCommands(stored.cwd)
+    const session = this.sessions.getOrCreate(sessionId, {
+      cwd: stored.cwd,
+      mcpServers: mcpServers ?? [],
+      conn: this.conn,
+      proc,
+      fileCommands,
+    })
+
+    this.store.upsert({
+      sessionId,
+      cwd: stored.cwd,
+      sessionFile: stored.sessionFile,
+    })
+
+    return session
+  }
+
   constructor(conn: AgentSideConnection, _config?: unknown) {
     this.conn = conn
     void _config
@@ -332,7 +378,7 @@ export class PiAcpAgent implements ACPAgent {
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
-    const session = this.sessions.get(params.sessionId)
+    const session = await this.autoRestoreSession(params.sessionId)
 
     const { message, images } = promptToPiMessage(params.prompt)
 
@@ -789,7 +835,7 @@ export class PiAcpAgent implements ACPAgent {
   }
 
   async cancel(params: CancelNotification): Promise<void> {
-    const session = this.sessions.get(params.sessionId)
+    const session = await this.autoRestoreSession(params.sessionId)
     await session.cancel()
   }
 
@@ -995,7 +1041,7 @@ export class PiAcpAgent implements ACPAgent {
   }
 
   async unstable_setSessionModel(params: { sessionId: string; modelId: string }): Promise<void> {
-    const session = this.sessions.get(params.sessionId)
+    const session = await this.autoRestoreSession(params.sessionId)
 
     // Accept either:
     //  - "provider/model" (preferred, matches how we advertise)
@@ -1029,7 +1075,7 @@ export class PiAcpAgent implements ACPAgent {
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
-    const session = this.sessions.get(params.sessionId)
+    const session = await this.autoRestoreSession(params.sessionId)
 
     const mode = String(params.modeId)
     if (!isThinkingLevel(mode)) {

--- a/test/component/agent-steering-followup-modes.test.ts
+++ b/test/component/agent-steering-followup-modes.test.ts
@@ -5,6 +5,9 @@ import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpe
 
 class FakeSessions {
   constructor(private readonly session: any) {}
+  maybeGet(_id: string) {
+    return this.session
+  }
   get(_id: string) {
     return this.session
   }

--- a/test/unit/builtin-commands.test.ts
+++ b/test/unit/builtin-commands.test.ts
@@ -5,6 +5,9 @@ import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpe
 
 class FakeSessions {
   constructor(private readonly session: any) {}
+  maybeGet(_id: string) {
+    return this.session
+  }
   get(_id: string) {
     return this.session
   }


### PR DESCRIPTION
## Problem

Fixes #28.

When `pi-acp` restarts (Zed reload, sleep/wake, crash), its in-memory `SessionManager` map is cleared. Any subsequent `prompt()`, `cancel()`, `setSessionModel()` or `setSessionMode()` call would then throw:

```
Invalid params: Unknown sessionId: <uuid>
```

...even though `session-map.json` on disk still has the mapping and the session file still exists. The underlying Pi session data is never lost — pi-acp just can't find it in memory.

## Fix

Add `PiAcpAgent.autoRestoreSession()` — a private async helper that:

1. Returns the session immediately if it is already in memory (`maybeGet`)
2. Falls back to `SessionStore` (reads `session-map.json` from disk) to locate the session file
3. Spawns a new `PiRpcProcess` attached to that existing session file, resuming the conversation
4. Re-registers it in the in-memory map via `getOrCreate()`

Then replaces the four `this.sessions.get(sessionId)` calls that throw on a miss with `await this.autoRestoreSession(sessionId)`:

- `prompt()`
- `cancel()`
- `unstable_setSessionModel()`
- `setSessionMode()`

## Tests

Updated `FakeSessions` mocks in two test files to expose `maybeGet()` (required by `autoRestoreSession`). All **72 tests pass**.

## Behaviour after fix

- If pi-acp restarts and Zed re-sends a message to an existing session, pi-acp transparently re-spawns the pi subprocess attached to the existing session file — the user sees no interruption.
- If the session is genuinely unknown (not in `session-map.json`), the original `Unknown sessionId` error is still thrown with a clear message.