### PR TITLE
fix: replace readline with manual \n-only JSONL reader

### DIFF
--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import * as readline from 'node:readline'
+import { StringDecoder } from 'node:string_decoder'
 import { getPiCommand, shouldUseShellForPiCommand } from './command.js'
 
 export class PiRpcSpawnError extends Error {
@@ -80,8 +80,14 @@ export class PiRpcProcess {
   private constructor(child: ChildProcessWithoutNullStreams) {
     this.child = child
 
-    const rl = readline.createInterface({ input: child.stdout })
-    rl.on('line', line => {
+    // Pi RPC uses strict LF-only JSONL framing. Node readline also splits on
+    // U+2028/U+2029 which are valid inside JSON strings, corrupting the stream.
+    // Use a manual buffer that splits only on \n.
+    const decoder = new StringDecoder('utf8')
+    let buf = ''
+
+    const onLine = (line: string) => {
+      if (line.endsWith('\r')) line = line.slice(0, -1)
       if (!line.trim()) return
       let msg: any
       try {
@@ -107,6 +113,20 @@ export class PiRpcProcess {
       }
 
       for (const h of this.eventHandlers) h(msg as PiRpcEvent)
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      buf += decoder.write(chunk)
+      let nl: number
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        onLine(buf.slice(0, nl))
+        buf = buf.slice(nl + 1)
+      }
+    })
+
+    child.stdout.on('end', () => {
+      buf += decoder.end()
+      if (buf.length > 0) onLine(buf)
     })
 
     child.on('exit', (code, signal) => {


### PR DESCRIPTION
## tl;dr:

In the rare edge-case that an agent outputs `U+2028` or `U+2029`, our use of node's `readline` will split on those, causing client-server confusion for everything afterward.

This PR is a manual workaround to parse those characters manually, adding 20 lines :(

## AI Disclosure

Every section after this was written by Claude. I hope the repro helps clarify and motivate this (or another) fix.

## Problem

`PiRpcProcess` uses `readline.createInterface` to read pi's stdout. Node's `readline` splits on U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) in addition to `\n`. These characters are valid inside JSON strings and `JSON.stringify` does not escape them, so any model output containing them produces well-formed JSONL that readline incorrectly splits.

The failure is silent: each fragment fails `JSON.parse` and falls into the prelude-capture branch, while the agent event is never dispatched. The effect compounds because the `partial` field on every subsequent `message_update` carries the full accumulated history — once one of these characters appears anywhere in the conversation, every remaining streaming event for that turn is corrupted.

This is called out explicitly in pi's [RPC framing docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md#framing):

> Do not use generic line readers that treat Unicode separators as newlines. In particular, Node `readline` is not protocol-compliant for RPC mode because it also splits on `U+2028` and `U+2029`.

Reproduced by asking an agent to  these characters in normal prose when prompted to include them (see below).

## Fix

Replace the `readline` interface with a `StringDecoder` + manual buffer that splits only on `0x0A`, following the pattern shown in pi's own RPC docs example client.

## Reproduction

You can use this python script to prompt an agent to output the characters:

```python
#!/usr/bin/env python3
"""Repro: pi-acp readline splits on U+2028/U+2029, silently dropping events."""
import subprocess, json, time, threading

proc = subprocess.Popen(['node', './dist/index.js'],
    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)

chunks, sid, done = [], None, threading.Event()

def read():
    global sid
    for line in proc.stdout:
        m = json.loads(line.strip() or '{}')
        if m.get('method') == 'session/update':
            u = m['params']['update']
            if u.get('sessionUpdate') == 'agent_message_chunk':
                chunks.append(u['content']['text'])
        elif r := m.get('result'):
            if 'sessionId' in r: sid = r['sessionId']
            if str(m.get('id')) == '3': done.set()

threading.Thread(target=read, daemon=True).start()

def rpc(id, method, params):
    proc.stdin.write(json.dumps({'jsonrpc':'2.0','id':str(id),'method':method,'params':params})+'\n')
    proc.stdin.flush()

rpc(1, 'initialize', {'protocolVersion':1,'clientCapabilities':{},'clientInfo':{'name':'x','version':'0'}})
time.sleep(1)
rpc(2, 'session/new', {'cwd':'/tmp','mcpServers':[]})
while not sid: time.sleep(0.3)

rpc(3, 'session/prompt', {'sessionId': sid, 'prompt': [{'type':'text',
    'text': 'Output verbatim, no explanation: BEFORE\u2028MIDDLE\u2029AFTER'}]})
done.wait(60)
proc.terminate()

result = ''.join(chunks)
print(repr(result[-60:]))
assert '\u2028' in result and '\u2029' in result, 'FAIL: U+2028/U+2029 dropped by readline'
print('PASS')
```

Expected output **before** the fix:
```
'...BEFORE'
AssertionError: FAIL: U+2028/U+2029 dropped by readline
```

Expected output **after** the fix:
```
'...BEFORE​MIDDLE​AFTER'
PASS
```

All 72 existing tests pass.