### PR TITLE
fix(acp): dedupe startup info emission

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -179,8 +179,7 @@ export class PiAcpSession {
   readonly mcpServers: McpServer[]
 
   private startupInfo: string | null = null
-  private startupInfoSentOutOfTurn = false
-  private startupInfoSentInPrompt = false
+  private startupInfoSent = false
 
   readonly proc: PiRpcProcess
   private readonly conn: AgentSideConnection
@@ -231,8 +230,7 @@ export class PiAcpSession {
 
   setStartupInfo(text: string) {
     this.startupInfo = text
-    this.startupInfoSentOutOfTurn = false
-    this.startupInfoSentInPrompt = false
+    this.startupInfoSent = false
   }
 
   /**
@@ -241,19 +239,16 @@ export class PiAcpSession {
    * callers can invoke this shortly after session/new returns.
    */
   sendStartupInfoIfPending(): void {
-    if (this.startupInfoSentOutOfTurn || !this.startupInfo) return
-    this.startupInfoSentOutOfTurn = true
-
-    this.emit({
-      sessionUpdate: 'agent_message_chunk',
-      content: { type: 'text', text: this.startupInfo }
-    })
+    this.sendStartupInfo()
   }
 
   private sendStartupInfoOnFirstPromptIfPending(): void {
-    if (this.startupInfoSentInPrompt || !this.startupInfo) return
-    this.startupInfoSentInPrompt = true
+    this.sendStartupInfo()
+  }
 
+  private sendStartupInfo(): void {
+    if (this.startupInfoSent || !this.startupInfo) return
+    this.startupInfoSent = true
     this.emit({
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text: this.startupInfo }

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -453,7 +453,7 @@ test('PiAcpSession: prompt resolves end_turn on agent_end', async () => {
   assert.equal(reason, 'end_turn')
 })
 
-test('PiAcpSession: re-emits startup info as the first chunk of the first prompt', async () => {
+test('PiAcpSession: does not re-emit startup info if already sent before first prompt', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
@@ -482,11 +482,10 @@ test('PiAcpSession: re-emits startup info as the first chunk of the first prompt
     sessionUpdate: 'agent_message_chunk',
     content: { type: 'text', text: notice }
   })
-  assert.equal(conn.updates[1]!.update.sessionUpdate, 'agent_message_chunk')
-  assert.deepEqual(conn.updates[1]!.update, {
-    sessionUpdate: 'agent_message_chunk',
-    content: { type: 'text', text: notice }
-  })
+  const startupChunks = conn.updates.filter(
+    u => u.update.sessionUpdate === 'agent_message_chunk' && (u.update as any).content?.text === notice
+  )
+  assert.equal(startupChunks.length, 1)
 
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })


### PR DESCRIPTION
- Dedupe ACP startup info emission across out-of-turn and first-prompt paths.
- Add component regression test for pre-prompt startup info followed by first prompt.
- Keep first-prompt fallback for clients that miss the out-of-turn opener.