### PR TITLE
Bridge extension UI requests through ACP permissions

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -1,20 +1,21 @@
 import type {
-  AgentSideConnection,
-  ContentBlock,
-  McpServer,
-  SessionUpdate,
-  ToolCallContent,
-  ToolCallLocation,
-  ToolKind
+    AgentSideConnection,
+    ContentBlock,
+    McpServer,
+    PermissionOption,
+    SessionUpdate,
+    ToolCallContent,
+    ToolCallLocation,
+    ToolKind
 } from '@agentclientprotocol/sdk'
 import { RequestError } from '@agentclientprotocol/sdk'
-import { maybeAuthRequiredError } from './auth-required.js'
 import { readFileSync } from 'node:fs'
 import { isAbsolute, resolve as resolvePath } from 'node:path'
 import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent } from '../pi-rpc/process.js'
+import { maybeAuthRequiredError } from './auth-required.js'
 import { SessionStore } from './session-store.js'
-import { toolResultToText } from './translate/pi-tools.js'
 import { expandSlashCommand, type FileSlashCommand } from './slash-commands.js'
+import { toolResultToText } from './translate/pi-tools.js'
 
 type SessionCreateParams = {
   cwd: string
@@ -37,6 +38,15 @@ type QueuedTurn = {
   resolve: (reason: StopReason) => void
   reject: (err: unknown) => void
 }
+
+type PermissionResponse = Awaited<ReturnType<AgentSideConnection['requestPermission']>>
+
+const CONFIRM_PERMISSION_OPTIONS: PermissionOption[] = [
+  { optionId: 'yes', name: 'Yes', kind: 'allow_once' },
+  { optionId: 'no', name: 'No', kind: 'reject_once' }
+]
+const EXTENSION_UI_RAW_INPUT_KEYS = ['title', 'message', 'options', 'placeholder', 'prefill'] as const
+const CHOICE_OPTION_PREFIX = 'choice-'
 
 function findUniqueLineNumber(text: string, needle: string): number | undefined {
   if (!needle) return undefined
@@ -596,6 +606,18 @@ export class PiAcpSession {
         break
       }
 
+      case 'extension_ui_request': {
+        void this.handleExtensionUiRequest(ev).catch(() => {
+          const id = stringProp(ev, 'id')
+          if (!id) {
+            return
+          }
+
+          void this.proc.sendExtensionUiResponse({ id, cancelled: true }).catch(() => {})
+        })
+        break
+      }
+
       case 'auto_retry_start': {
         this.emit({
           sessionUpdate: 'agent_message_chunk',
@@ -676,6 +698,140 @@ export class PiAcpSession {
         break
     }
   }
+
+  private async handleExtensionUiRequest(ev: PiRpcEvent): Promise<void> {
+    const id = stringProp(ev, 'id')
+    const method = stringProp(ev, 'method')
+    if (!id) {
+      return
+    }
+
+    if (method === 'select') {
+      await this.handleExtensionSelect(ev, id)
+      return
+    }
+
+    if (method === 'confirm') {
+      await this.handleExtensionConfirm(ev, id)
+      return
+    }
+
+    if (method === 'input' || method === 'editor') {
+      this.emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: {
+          type: 'text',
+          text: `Pi ${method} UI request is not supported in ACP yet; cancelling it.`
+        } satisfies ContentBlock
+      })
+      await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+      return
+    }
+
+    if (method === 'notify') {
+      this.emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: stringProp(ev, 'message') ?? 'Pi notification' } satisfies ContentBlock
+      })
+      await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+      return
+    }
+
+    await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+  }
+
+  private async handleExtensionSelect(ev: PiRpcEvent, id: string): Promise<void> {
+    const rawOptions = ev.options
+    const options = Array.isArray(rawOptions) ? rawOptions.map(option => String(option)) : []
+    if (!options.length) {
+      await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+      return
+    }
+
+    const permissionOptions: PermissionOption[] = options.map((name, index) => ({
+      optionId: `${CHOICE_OPTION_PREFIX}${index}`,
+      name,
+      kind: 'allow_once'
+    }))
+
+    const selected = await this.requestExtensionPermission(id, ev, permissionOptions)
+    if (selected === null) {
+      return
+    }
+
+    const selectedOptionId = selected.outcome.outcome === 'selected' ? selected.outcome.optionId : null
+    const index = selectedOptionId === null ? null : optionIndex(selectedOptionId)
+    const value = index === null ? null : (options.at(index) ?? null)
+    await this.proc.sendExtensionUiResponse(value === null ? { id, cancelled: true } : { id, value })
+  }
+
+  private async handleExtensionConfirm(ev: PiRpcEvent, id: string): Promise<void> {
+    const selected = await this.requestExtensionPermission(id, ev, CONFIRM_PERMISSION_OPTIONS)
+    if (selected === null) {
+      return
+    }
+
+    if (selected.outcome.outcome === 'cancelled') {
+      await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+      return
+    }
+
+    await this.proc.sendExtensionUiResponse({ id, confirmed: selected.outcome.optionId === 'yes' })
+  }
+
+  private async requestExtensionPermission(
+    id: string,
+    ev: PiRpcEvent,
+    options: PermissionOption[]
+  ): Promise<PermissionResponse | null> {
+    try {
+      return await this.conn.requestPermission({
+        sessionId: this.sessionId,
+        toolCall: extensionUiToolCall(id, ev),
+        options
+      })
+    } catch {
+      await this.proc.sendExtensionUiResponse({ id, cancelled: true })
+      return null
+    }
+  }
+}
+
+function extensionUiToolCall(id: string, ev: PiRpcEvent) {
+  const method = stringProp(ev, 'method') ?? 'ui'
+  const title = stringProp(ev, 'title') ?? `Pi ${method}`
+  const rawInput: Record<string, unknown> = { method }
+
+  for (const key of EXTENSION_UI_RAW_INPUT_KEYS) {
+    if (Object.hasOwn(ev, key)) rawInput[key] = ev[key]
+  }
+
+  return {
+    toolCallId: `pi-ui-${id}`,
+    title,
+    kind: 'other' as const,
+    status: 'pending' as const,
+    rawInput
+  }
+}
+
+function stringProp(source: Record<string, unknown>, key: string): string | null {
+  const value = source[key]
+  return typeof value === 'string' ? value : null
+}
+
+function optionIndex(optionId: string): number | null {
+  if (!optionId.startsWith(CHOICE_OPTION_PREFIX)) {
+    return null
+  }
+
+  const rawIndex = optionId.slice(CHOICE_OPTION_PREFIX.length)
+  if (!rawIndex) {
+    return null
+  }
+
+  const index = Number(rawIndex)
+  return Number.isSafeInteger(index) && index >= 0 && String(index) === rawIndex ? index : null
 }
 
 function formatAutoRetryMessage(ev: PiRpcEvent): string {

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -61,6 +61,11 @@ type PiRpcResponse = {
   error?: string
 }
 
+type PiExtensionUiResponse =
+  | { id: string; value: string }
+  | { id: string; confirmed: boolean }
+  | { id: string; cancelled: true }
+
 export type PiRpcEvent = Record<string, unknown>
 
 type SpawnParams = {
@@ -314,25 +319,39 @@ export class PiRpcProcess {
     return res.data
   }
 
+  async sendExtensionUiResponse(response: PiExtensionUiResponse): Promise<void> {
+    await this.writeLine(`${JSON.stringify({ type: 'extension_ui_response', ...response })}\n`)
+  }
+
   private request(cmd: PiRpcCommand): Promise<PiRpcResponse> {
     const id = crypto.randomUUID()
     const withId = { ...cmd, id }
 
-    const line = JSON.stringify(withId) + '\n'
+    const line = `${JSON.stringify(withId)}\n`
 
     return new Promise<PiRpcResponse>((resolve, reject) => {
       this.pending.set(id, { resolve, reject })
 
-      try {
-        this.child.stdin.write(line, err => {
-          if (err) {
-            this.pending.delete(id)
-            reject(err)
-          }
-        })
-      } catch (e) {
+      void this.writeLine(line).catch(error => {
         this.pending.delete(id)
-        reject(e)
+        reject(error)
+      })
+    })
+  }
+
+  private writeLine(line: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      try {
+        this.child.stdin.write(line, error => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      } catch (error: unknown) {
+        reject(error)
       }
     })
   }

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -128,6 +128,128 @@ test('PiAcpSession: emits tool locations from pi path args', async () => {
   assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: `${process.cwd()}/src/acp/session.ts` }])
 })
 
+test('PiAcpSession: handles extension select via ACP permission request', async () => {
+  const conn = new FakeAgentSideConnection()
+  conn.nextPermissionResponse = { outcome: { outcome: 'selected', optionId: 'choice-1' } }
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'extension_ui_request',
+    id: 'ui-1',
+    method: 'select',
+    title: 'Pick one',
+    options: ['Alpha', 'Beta']
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.permissionRequests.length, 1)
+  assert.deepEqual(conn.permissionRequests[0], {
+    sessionId: 's1',
+    toolCall: {
+      toolCallId: 'pi-ui-ui-1',
+      title: 'Pick one',
+      kind: 'other',
+      status: 'pending',
+      rawInput: { method: 'select', title: 'Pick one', options: ['Alpha', 'Beta'] }
+    },
+    options: [
+      { optionId: 'choice-0', name: 'Alpha', kind: 'allow_once' },
+      { optionId: 'choice-1', name: 'Beta', kind: 'allow_once' }
+    ]
+  })
+  assert.deepEqual(proc.extensionUiResponses, [{ id: 'ui-1', value: 'Beta' }])
+})
+
+test('PiAcpSession: handles extension confirm via ACP permission request', async () => {
+  const conn = new FakeAgentSideConnection()
+  conn.nextPermissionResponse = { outcome: { outcome: 'selected', optionId: 'no' } }
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'extension_ui_request',
+    id: 'ui-2',
+    method: 'confirm',
+    title: 'Clear session?',
+    message: 'All messages will be lost.'
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.permissionRequests.length, 1)
+  assert.deepEqual((conn.permissionRequests[0] as any).options, [
+    { optionId: 'yes', name: 'Yes', kind: 'allow_once' },
+    { optionId: 'no', name: 'No', kind: 'reject_once' }
+  ])
+  assert.deepEqual(proc.extensionUiResponses, [{ id: 'ui-2', confirmed: false }])
+})
+
+test('PiAcpSession: sends cancelled response when ACP confirm is cancelled', async () => {
+  const conn = new FakeAgentSideConnection()
+  conn.nextPermissionResponse = { outcome: { outcome: 'cancelled' } }
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'extension_ui_request', id: 'ui-5', method: 'confirm', title: 'Continue?' })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.deepEqual(proc.extensionUiResponses, [{ id: 'ui-5', cancelled: true }])
+})
+
+test('PiAcpSession: cancels unsupported input and editor extension UI requests with visible fallback', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'extension_ui_request', id: 'ui-3', method: 'input', title: 'Enter name' })
+  proc.emit({ type: 'extension_ui_request', id: 'ui-4', method: 'editor', title: 'Edit text' })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.deepEqual(proc.extensionUiResponses, [
+    { id: 'ui-3', cancelled: true },
+    { id: 'ui-4', cancelled: true }
+  ])
+  assert.equal(conn.updates.length, 2)
+  assert.match((conn.updates[0]!.update as any).content.text, /input UI request is not supported/)
+  assert.match((conn.updates[1]!.update as any).content.text, /editor UI request is not supported/)
+})
+
 test('PiAcpSession: emits agent_message_chunk for auto_retry_start with attempt/maxAttempts and rounded delay', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -5,9 +5,20 @@ type SessionUpdateMsg = Parameters<AgentSideConnection['sessionUpdate']>[0]
 
 export class FakeAgentSideConnection {
   readonly updates: SessionUpdateMsg[] = []
+  readonly permissionRequests: unknown[] = []
+  nextPermissionResponse: { outcome: { outcome: 'selected'; optionId: string } | { outcome: 'cancelled' } } = {
+    outcome: { outcome: 'selected', optionId: 'allow' }
+  }
 
   async sessionUpdate(msg: SessionUpdateMsg): Promise<void> {
     this.updates.push(msg)
+  }
+
+  async requestPermission(
+    params: unknown
+  ): Promise<{ outcome: { outcome: 'selected'; optionId: string } | { outcome: 'cancelled' } }> {
+    this.permissionRequests.push(params)
+    return this.nextPermissionResponse
   }
 }
 
@@ -16,6 +27,7 @@ export class FakePiRpcProcess {
 
   // spies
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
+  readonly extensionUiResponses: unknown[] = []
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -37,6 +49,9 @@ export class FakePiRpcProcess {
     this.abortCount += 1
   }
 
+  async sendExtensionUiResponse(response: unknown): Promise<void> {
+    this.extensionUiResponses.push(response)
+  }
 
   async getState(): Promise<any> {
     return {}


### PR DESCRIPTION
## Summary

This PR makes pi extension UI prompts work better in ACP clients like Zed.

Extensions can now ask the user to pick from a list or confirm an action, and `pi-acp` bridges those requests through ACP permission prompts instead of leaving pi waiting for input it can’t receive.

## What changed

- Added support for extension `select` requests via ACP permission options.
- Added support for extension `confirm` requests with Yes/No choices.
- Sends the chosen answer back to pi with `extension_ui_response`.
- Shows a friendly fallback message for unsupported `input` and `editor` requests, then cancels them cleanly.
- Surfaces extension notifications as assistant text.
- Adds defensive cancellation paths so unknown/error cases don’t hang the pi subprocess.
- Added tests for the new extension UI flows.

<img width="514" height="411" alt="zed_example" src="https://github.com/user-attachments/assets/6275fcee-3815-4dac-804e-c26f53f327e7" />