### PR TITLE
fix: pass error information across the bridge

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -371,6 +371,13 @@ export class PiAcpSession {
         if (authErr) {
           this.pendingTurn?.reject(authErr)
         } else {
+          // Surface error message to client before completing the turn.
+          const errorMessage = String((err as any)?.message ?? err ?? 'Unknown error')
+          this.emit({
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: `Error: ${errorMessage}` }
+          })
+
           const reason: StopReason = this.cancelRequested ? 'cancelled' : 'error'
           this.pendingTurn?.resolve(reason)
         }
@@ -668,6 +675,16 @@ export class PiAcpSession {
               _meta: { piAcp: { queueDepth: 0, running: false } }
             })
           }
+        })
+        break
+      }
+
+      case 'agent_error':
+      case 'error': {
+        const message = String((ev as any).message ?? (ev as any).error ?? 'Unknown error')
+        this.emit({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: `Error: ${message}` } satisfies ContentBlock
         })
         break
       }


### PR DESCRIPTION
Addresses #5 

(though I have tested this less thouroughly than I might like to, this is mostly meant as a reasonable stab/starting point to a solution.)
