### PR TITLE
signal update_usage at the end of each turn

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -470,6 +470,44 @@ export class PiAcpSession {
     this.bashOutputSnapshots.delete(toolCallId)
   }
 
+  /**
+   * Translate pi's session stats into an ACP `usage_update` notification so
+   * clients can render live context-window / cost usage.
+   *
+   * `usage_update` is part of the ACP schema (currently marked UNSTABLE). It
+   * carries required `used` + `size` token counts and an optional
+   * `cost: { amount, currency }`. We can only report once pi knows the
+   * model's context window, since `used`/`size` are required and paired.
+   */
+  async publishUsage(): Promise<void> {
+    let stats: any
+    try {
+      stats = await this.proc.getSessionStats()
+    } catch {
+      return
+    }
+    if (!stats || typeof stats !== 'object') return
+
+    const ctx = stats.contextUsage
+    const size = ctx && typeof ctx === 'object' && typeof ctx.contextWindow === 'number' ? ctx.contextWindow : undefined
+
+    // No window known yet (no model bound / before the first response): we
+    // can't emit a schema-valid usage_update, so skip.
+    if (size === undefined) return
+
+    // `tokens` may be an estimate before the first response, and null
+    // post-compaction until the next turn (treat as 0 — directionally correct).
+    const used = typeof ctx.tokens === 'number' ? ctx.tokens : 0
+    const cost = typeof stats.cost === 'number' ? { amount: stats.cost, currency: 'USD' } : undefined
+
+    this.emit({
+      sessionUpdate: 'usage_update',
+      used,
+      size,
+      ...(cost ? { cost } : {})
+    })
+  }
+
   private startTurn(t: QueuedTurn): void {
     this.cancelRequested = false
     this.inAgentLoop = false
@@ -829,6 +867,8 @@ export class PiAcpSession {
       }
 
       case 'agent_end': {
+        // Emit a usage_update so cost / context numbers are current at turn end.
+        void this.publishUsage()
         // Ensure all updates derived from pi events are delivered before we resolve
         // the ACP `session/prompt` request.
         void this.flushEmits().finally(() => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -657,6 +657,122 @@ test('PiAcpSession: prompt resolves end_turn on agent_end', async () => {
   assert.equal(reason, 'end_turn')
 })
 
+test('PiAcpSession: emits usage_update on agent_end from session stats', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    cost: 0.1234,
+    contextUsage: { tokens: 1500, contextWindow: 200000, percent: 0.75 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  await p
+
+  const usage = conn.updates.find(u => u.update.sessionUpdate === 'usage_update')
+  assert.ok(usage, 'expected a usage_update notification')
+  assert.equal(usage!.sessionId, 's1')
+  assert.deepEqual(usage!.update, {
+    sessionUpdate: 'usage_update',
+    used: 1500,
+    size: 200000,
+    cost: { amount: 0.1234, currency: 'USD' }
+  })
+})
+
+test('PiAcpSession: usage_update omits cost when stats has none and defaults used to 0', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  // Post-compaction: window known but token count not yet available.
+  proc.sessionStats = { contextUsage: { tokens: null, contextWindow: 200000, percent: null } }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  await p
+
+  const usage = conn.updates.find(u => u.update.sessionUpdate === 'usage_update')
+  assert.ok(usage, 'expected a usage_update notification')
+  assert.deepEqual(usage!.update, {
+    sessionUpdate: 'usage_update',
+    used: 0,
+    size: 200000
+  })
+})
+
+test('PiAcpSession: skips usage_update when no context window is known', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  // No contextUsage (no model bound / before first response); only cost.
+  proc.sessionStats = { cost: 0.5 }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  await p
+
+  assert.equal(
+    conn.updates.find(u => u.update.sessionUpdate === 'usage_update'),
+    undefined,
+    'should not emit usage_update without a context window'
+  )
+})
+
+test('PiAcpSession: agent_end still resolves when session stats are unavailable', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  // sessionStats left null -> getSessionStats() rejects.
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  const reason = await p
+
+  assert.equal(reason, 'end_turn')
+  assert.equal(proc.getSessionStatsCount, 1)
+  assert.equal(
+    conn.updates.find(u => u.update.sessionUpdate === 'usage_update'),
+    undefined
+  )
+})
+
 test('PiAcpSession: does not re-emit startup info on first prompt after it was already sent', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -29,6 +29,11 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   abortCount = 0
+  getSessionStatsCount = 0
+
+  // Configurable return value for getSessionStats(). When null, the call
+  // rejects (mirroring pi being unavailable / the RPC failing).
+  sessionStats: any = null
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
     this.handlers.push(handler)
@@ -55,6 +60,12 @@ export class FakePiRpcProcess {
 
   async getState(): Promise<any> {
     return {}
+  }
+
+  async getSessionStats(): Promise<any> {
+    this.getSessionStatsCount += 1
+    if (this.sessionStats === null) throw new Error('getSessionStats unavailable')
+    return this.sessionStats
   }
 
   async getAvailableModels(): Promise<any> {


### PR DESCRIPTION
Working on [hydra-acp](https://github.com/smagnuso/hydra-acp) I noticed that usage is not updated properly in pi
