### PR TITLE
feat: add /reload ACP slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Loaded from:
 - `/name <name>` – set session display name
 - `/queue all|one-at-a-time` – set pi queue mode (unstable feature)
 - `/changelog` – print the installed pi changelog (best-effort)
+- `/reload` – reload prompts, skills, extensions, and context files for the current ACP session
 - `/steering` - maps to `pi` Steering Mode, get/set
 - `/follow-up` - pats to `pi` Follow-up Mode, get/set
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -77,6 +77,10 @@ function builtinAvailableCommands(): AvailableCommand[] {
     {
       name: 'changelog',
       description: 'Show pi changelog'
+    },
+    {
+      name: 'reload',
+      description: 'Reload prompts, skills, extensions, and context files for this ACP session'
     }
   ]
 }
@@ -545,6 +549,63 @@ export class PiAcpAgent implements ACPAgent {
           update: {
             sessionUpdate: 'agent_message_chunk',
             content: { type: 'text', text: `Follow-up mode set to: ${modeRaw}` }
+          }
+        })
+
+        return { stopReason: 'end_turn' }
+      }
+
+      if (cmd === 'reload') {
+        if (typeof (session as any).isBusy === 'function' && (session as any).isBusy()) {
+          await this.conn.sessionUpdate({
+            sessionId: session.sessionId,
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: {
+                type: 'text',
+                text: 'Wait for the current response to finish before reloading.'
+              }
+            }
+          })
+          return { stopReason: 'end_turn' }
+        }
+
+        const reloadedFileCommands = loadSlashCommands(session.cwd)
+        const reloadedEnableSkillCommands = getEnableSkillCommands(session.cwd)
+
+        await session.reload({
+          fileCommands: reloadedFileCommands,
+          piCommand: process.env.PI_ACP_PI_COMMAND
+        })
+
+        let availableCommands: AvailableCommand[]
+        try {
+          const pi = (await session.proc.getCommands()) as any
+          const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
+            enableSkillCommands: reloadedEnableSkillCommands,
+            includeExtensionCommands: false
+          })
+          availableCommands = mergeCommands(commands, builtinAvailableCommands())
+        } catch {
+          availableCommands = mergeCommands(toAvailableCommands(reloadedFileCommands), builtinAvailableCommands())
+        }
+
+        await this.conn.sessionUpdate({
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands
+          }
+        })
+
+        await this.conn.sessionUpdate({
+          sessionId: session.sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: 'Reloaded prompts, skills, extensions, and context files for this session.'
+            }
           }
         })
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -182,9 +182,10 @@ export class PiAcpSession {
   private startupInfoSentOutOfTurn = false
   private startupInfoSentInPrompt = false
 
-  readonly proc: PiRpcProcess
+  private _proc: PiRpcProcess
+  private procUnsubscribe: (() => void) | null = null
   private readonly conn: AgentSideConnection
-  private readonly fileCommands: FileSlashCommand[]
+  private fileCommands: FileSlashCommand[]
 
   // Used to map abort semantics to ACP stopReason.
   // Applies to the currently running turn.
@@ -222,11 +223,20 @@ export class PiAcpSession {
     this.sessionId = opts.sessionId
     this.cwd = opts.cwd
     this.mcpServers = opts.mcpServers
-    this.proc = opts.proc
+    this._proc = opts.proc
     this.conn = opts.conn
     this.fileCommands = opts.fileCommands ?? []
 
-    this.proc.onEvent(ev => this.handlePiEvent(ev))
+    this.bindProc(this._proc)
+  }
+
+  get proc(): PiRpcProcess {
+    return this._proc
+  }
+
+  private bindProc(proc: PiRpcProcess): void {
+    this.procUnsubscribe?.()
+    this.procUnsubscribe = proc.onEvent(ev => this.handlePiEvent(ev))
   }
 
   setStartupInfo(text: string) {
@@ -258,6 +268,48 @@ export class PiAcpSession {
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text: this.startupInfo }
     })
+  }
+
+  isBusy(): boolean {
+    return this.pendingTurn !== null || this.inAgentLoop || this.turnQueue.length > 0
+  }
+
+  async reload(opts: { fileCommands?: FileSlashCommand[]; piCommand?: string } = {}): Promise<void> {
+    if (this.isBusy()) {
+      throw new Error('Cannot reload while a prompt is running or queued.')
+    }
+
+    const state = (await this._proc.getState()) as any
+    const sessionFile = typeof state?.sessionFile === 'string' ? state.sessionFile.trim() : ''
+
+    if (!sessionFile) {
+      throw new Error('Cannot reload session: session file unavailable.')
+    }
+
+    const nextProc = await PiRpcProcess.spawn({
+      cwd: this.cwd,
+      sessionPath: sessionFile,
+      piCommand: opts.piCommand
+    })
+
+    const previousProc = this._proc
+    this._proc = nextProc
+    this.bindProc(nextProc)
+
+    if (opts.fileCommands) {
+      this.fileCommands = opts.fileCommands
+    }
+
+    this.cancelRequested = false
+    this.inAgentLoop = false
+    this.currentToolCalls.clear()
+    this.editSnapshots.clear()
+
+    try {
+      previousProc.dispose?.()
+    } catch {
+      // ignore
+    }
   }
 
   async prompt(message: string, images: unknown[] = []): Promise<StopReason> {
@@ -321,7 +373,7 @@ export class PiAcpSession {
     }
 
     // Abort the currently running turn (if any). If nothing is running, this is a no-op.
-    await this.proc.abort()
+    await this._proc.abort()
   }
 
   wasCancelRequested(): boolean {
@@ -362,7 +414,7 @@ export class PiAcpSession {
     // Kick off pi, but completion is determined by pi events, not the RPC response.
     // Important: pi may emit multiple `turn_end` events (e.g. when the model requests tools).
     // The full prompt is finished when we see `agent_end`.
-    this.proc.prompt(t.message, t.images).catch(err => {
+    this._proc.prompt(t.message, t.images).catch(err => {
       // If the subprocess errors before we get an `agent_end`, treat as error unless cancelled.
       // Also ensure we flush any already-enqueued updates first.
       void this.flushEmits().finally(() => {

--- a/test/unit/builtin-commands.test.ts
+++ b/test/unit/builtin-commands.test.ts
@@ -55,3 +55,68 @@ test('PiAcpAgent: /name sets session display name adapter-side', async () => {
   const last = conn.updates.at(-1)
   assert.match((last as any).update.content.text, /Session name set: My Session/)
 })
+
+test('PiAcpAgent: /reload is handled adapter-side', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess() as any
+  proc.getCommands = async () => ({ commands: [] })
+
+  let reloaded = false
+
+  const agent = new PiAcpAgent(asAgentConn(conn))
+  ;(agent as any).sessions = new FakeSessions({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    proc,
+    fileCommands: [],
+    isBusy: () => false,
+    reload: async () => {
+      reloaded = true
+    }
+  }) as any
+
+  const res = await agent.prompt({
+    sessionId: 's1',
+    prompt: [{ type: 'text', text: '/reload' }]
+  } as any)
+
+  assert.equal(res.stopReason, 'end_turn')
+  assert.equal(proc.prompts.length, 0)
+  assert.equal(reloaded, true)
+
+  const commandsUpdate = conn.updates.find(u => (u as any).update?.sessionUpdate === 'available_commands_update')
+  assert.ok(commandsUpdate)
+  assert.ok((commandsUpdate as any).update.availableCommands.some((c: any) => c.name === 'reload'))
+
+  const last = conn.updates.at(-1)
+  assert.match((last as any).update.content.text, /Reloaded prompts, skills, extensions, and context files/)
+})
+
+test('PiAcpAgent: /reload waits until idle', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess() as any
+
+  let reloaded = false
+
+  const agent = new PiAcpAgent(asAgentConn(conn))
+  ;(agent as any).sessions = new FakeSessions({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    proc,
+    fileCommands: [],
+    isBusy: () => true,
+    reload: async () => {
+      reloaded = true
+    }
+  }) as any
+
+  const res = await agent.prompt({
+    sessionId: 's1',
+    prompt: [{ type: 'text', text: '/reload' }]
+  } as any)
+
+  assert.equal(res.stopReason, 'end_turn')
+  assert.equal(reloaded, false)
+  const last = conn.updates.at(-1)
+  assert.match((last as any).update.content.text, /Wait for the current response to finish before reloading/)
+})


### PR DESCRIPTION
## Summary
- add `/reload` to pi-acp built-in ACP slash commands
- reload the current ACP session by restarting the underlying Pi RPC process against the same session file
- refresh advertised available commands after reload and block reload while a prompt is still running

## Why
Pi supports `/reload` in interactive mode, but `pi-acp` currently reports `/reload is not a recognized command in pi-acp`.
This makes it hard to pick up prompt/skill/extension/context-file changes without starting a fresh ACP session.

## Implementation notes
- adds adapter-side `/reload` handling in `src/acp/agent.ts`
- adds `PiAcpSession.reload()` plus `isBusy()` in `src/acp/session.ts`
- rebinds the ACP session to a freshly spawned Pi RPC process using the same persisted `sessionFile`
- reloads file-based slash commands and re-emits `available_commands_update`
- documents `/reload` in the README
- adds unit tests for success and busy-session guard paths

## Verification
- `npm test`
- `npm run build`
- `npm run lint`
