### PR TITLE
feat: forward session_info_changed as live title update

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -538,14 +538,9 @@ export class PiAcpAgent implements ACPAgent {
           return { stopReason: 'end_turn' }
         }
 
-        await this.conn.sessionUpdate({
-          sessionId: session.sessionId,
-          update: {
-            sessionUpdate: 'session_info_update',
-            title: name,
-            updatedAt: new Date().toISOString()
-          }
-        })
+        // No need to emit session_info_update here — session.proc.setSessionName()
+        // triggers a session_info_changed event from pi, which the session event handler
+        // forwards as session_info_update automatically.
 
         await this.conn.sessionUpdate({
           sessionId: session.sessionId,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -855,6 +855,20 @@ export class PiAcpSession {
         break
       }
 
+      case 'session_info_changed': {
+        // Forward pi-side session name changes as a live title update, so the
+        // title stays in sync without waiting for a session reload.
+        const name = stringProp(ev, 'name')
+        if (name) {
+          this.emit({
+            sessionUpdate: 'session_info_update',
+            title: name,
+            updatedAt: new Date().toISOString()
+          })
+        }
+        break
+      }
+
       default:
         break
     }

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -34,6 +34,51 @@ test('PiAcpSession: emits agent_message_chunk for text_delta', async () => {
   })
 })
 
+test('PiAcpSession: forwards session_info_changed as a session_info_update title', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'session_info_changed', name: 'Fix login redirect bug' })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.equal(conn.updates[0]!.sessionId, 's1')
+  assert.equal(conn.updates[0]!.update.sessionUpdate, 'session_info_update')
+  assert.equal((conn.updates[0]!.update as any).title, 'Fix login redirect bug')
+  assert.equal(typeof (conn.updates[0]!.update as any).updatedAt, 'string')
+})
+
+test('PiAcpSession: ignores session_info_changed with no usable name', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'session_info_changed' })
+  proc.emit({ type: 'session_info_changed', name: 123 } as any)
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 0)
+})
+
 test('PiAcpSession: emits agent_thought_chunk for thinking_delta', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/unit/builtin-commands.test.ts
+++ b/test/unit/builtin-commands.test.ts
@@ -52,9 +52,10 @@ test('PiAcpAgent: /name sets session display name adapter-side', async () => {
   assert.equal(res.stopReason, 'end_turn')
   assert.equal(proc.prompts.length, 0)
   assert.equal(setTo, 'My Session')
-  const info = conn.updates.find(u => (u as any).update?.sessionUpdate === 'session_info_update')
-  assert.equal((info as any)?.update?.title, 'My Session')
 
+  // The session_info_update title is no longer emitted directly by the /name
+  // handler — it flows through the session_info_changed event path instead.
+  // Verify only the confirmation message is emitted here.
   const last = conn.updates.at(-1)
   assert.match((last as any).update.content.text, /Session name set: My Session/)
 })


### PR DESCRIPTION
## What

Forward pi's `session_info_changed` RPC event as an ACP `session_info_update` notification so thread titles update live in the client. Fixes #24...

## Why

When a session name changes — via `/name`, `set_session_name` RPC, or an extension calling `pi.setSessionName()` — pi emits a `session_info_changed` event over the RPC stream. The adapter previously dropped this event, so the ACP client only saw the title on session reload.

The `/name` command had its own manual `session_info_update` emit to work around this. That workaround is now removed — all title updates flow through the same path.

## How

- Handle `session_info_changed` in the pi event switch, extract the `name` field, emit `session_info_update` with `title` + `updatedAt`.
- Remove the redundant manual `session_info_update` from the `/name` handler.
- Two tests: one for the happy path, one for missing/invalid name.

This is complementary to #25 (which generates titles inside pi-acp). This PR enables the lower-level plumbing so that **any** pi-side name change is forwarded live, including from extensions.

## Example: auto-title via a pi extension

With this plumbing in place, a global pi extension at `~/.pi/agent/extensions/auto-title.ts` can auto-generate titles without any pi-acp changes:

<details>
<summary>auto-title.ts (click to expand)</summary>

```ts
import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
import { streamSimple } from "@earendil-works/pi-ai";

const TITLE_PROVIDER = "anthropic";
const TITLE_MODEL = "claude-haiku-4-5";

const SYSTEM_PROMPT =
  "You generate a concise title for a coding/chat session. " +
  "Reply with ONLY the title: 3-6 words, no quotes, no trailing punctuation, " +
  "Title Case, max 60 characters. Summarise the user's first message.";

function firstUserText(ctx: ExtensionContext): string | undefined {
  for (const entry of ctx.sessionManager.getBranch()) {
    const msg = (entry as any).message;
    if (entry.type === "message" && msg?.role === "user") {
      const content = msg.content;
      const text =
        typeof content === "string"
          ? content
          : (content ?? [])
              .filter((c: any) => c.type === "text")
              .map((c: any) => c.text)
              .join(" ");
      const trimmed = text?.trim();
      if (trimmed) return trimmed;
    }
  }
  return undefined;
}

function cleanTitle(raw: string): string {
  return raw
    .replace(/^["'`\s]+|["'`\s.]+$/g, "")
    .replace(/\s+/g, " ")
    .slice(0, 60)
    .trim();
}

export default function (pi: ExtensionAPI) {
  let attempted = false;

  pi.on("agent_end", async (_event, ctx) => {
    // Note: getSessionName/setSessionName live on `pi`, not `ctx`.
    if (attempted || pi.getSessionName()) return;
    attempted = true;

    const prompt = firstUserText(ctx);
    if (!prompt) return;

    const titleModel = ctx.modelRegistry.find(TITLE_PROVIDER, TITLE_MODEL);
    const candidates = [titleModel, ctx.model].filter(
      (m, i, arr): m is NonNullable<typeof m> =>
        !!m && arr.findIndex((x) => x && x.id === m.id) === i,
    );
    if (candidates.length === 0) return;

    try {
      let title = "";
      for (const model of candidates) {
        const resolved = await ctx.modelRegistry.getApiKeyAndHeaders(model);
        if (!resolved.ok) continue;
        const stream = streamSimple(model, {
          systemPrompt: SYSTEM_PROMPT,
          messages: [{ role: "user", content: prompt.slice(0, 4000), timestamp: Date.now() }],
        }, {
          apiKey: resolved.apiKey, env: resolved.env,
          headers: resolved.headers, signal: ctx.signal,
        });
        const finalMessage = await stream.result();
        if ((finalMessage as any).stopReason === "error") continue;
        const text = finalMessage.content
          .filter((c: any) => c.type === "text")
          .map((c: any) => c.text).join("").trim();
        title = cleanTitle(text);
        if (title) break;
      }
      if (title) pi.setSessionName(title);
    } catch {
      // Best-effort; never disrupt the session.
    }
  });
}
```
</details>

### Gotchas discovered while building the extension

1. **`streamSimple` does not throw on API errors** — e.g. a 404 for an unavailable model returns `stopReason: "error"` with empty `content` rather than throwing. Extensions must check `stopReason` and fall back.
2. **pi-acp swallows the pi child's stderr** (`child.stderr.on("data", () => {})`) — extension `process.stderr.write()` goes to a black hole. Use file-based logging for debugging.