### PR TITLE
fix(acp): emit startup info in-turn, not out-of-turn after session/new

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -385,9 +385,13 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    // Try to send it immediately after session/new returns; if the client ignores it,
-    // it will still be emitted as the first chunk of the first prompt.
-    if (preludeText) setTimeout(() => session.sendStartupInfoIfPending(), 0)
+    // NOTE: Do not emit the startup banner as an `agent_message_chunk` here.
+    // Per the ACP protocol, per-turn updates (agent_message_chunk) must arrive
+    // while a `session/prompt` is active; emitting it right after `session/new`
+    // produces an out-of-turn update that strict ACP clients reject (see issue #59).
+    // Instead, it is flushed at the start of the first prompt turn (see `startTurn`)
+    // and also exposed via `_meta.piAcp.startupInfo` for clients that render it
+    // themselves (e.g. Zed).
 
     // Advertise slash commands (ACP: available_commands_update)
     // Important: some clients (e.g. Zed) will ignore notifications for an unknown sessionId.

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -319,9 +319,10 @@ export class PiAcpSession {
   }
 
   /**
-   * Best-effort attempt to send startup info outside of a prompt turn.
-   * Some clients (e.g. Zed) may only render agent messages once the UI is ready;
-   * callers can invoke this shortly after session/new returns.
+   * Emit the deferred startup info as an `agent_message_chunk`, but only if it
+   * hasn't been sent yet. Must be called while a `session/prompt` turn is active
+   * (i.e. from `startTurn`), since ACP forbids per-turn updates outside of a
+   * prompt turn. See https://github.com/svkozak/pi-acp/issues/59.
    */
   sendStartupInfoIfPending(): void {
     if (this.startupInfoSent || !this.startupInfo) return
@@ -475,6 +476,12 @@ export class PiAcpSession {
     this.inAgentLoop = false
 
     this.pendingTurn = { resolve: t.resolve, reject: t.reject }
+
+    // Flush the deferred startup banner (pi version / context / skills / extensions) as
+    // the first agent_message_chunk of this turn. ACP requires per-turn updates to
+    // arrive while a `session/prompt` is active, so this must happen here rather than
+    // immediately after session/new (which strict ACP clients reject as out-of-turn).
+    this.sendStartupInfoIfPending()
 
     // Publish queue depth (0 because we're starting the turn now).
     this.emit({

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -697,6 +697,61 @@ test('PiAcpSession: does not re-emit startup info on first prompt after it was a
   assert.equal(reason, 'end_turn')
 })
 
+test('PiAcpSession: emits deferred startup info in-turn (not out-of-turn) on first prompt', async () => {
+  // Regression test for https://github.com/svkozak/pi-acp/issues/59
+  // Startup info must NOT be emitted as an agent_message_chunk immediately after
+  // session/new (no prompt is active -> ACP rejects it as out-of-turn). Instead it
+  // is flushed as the first agent_message_chunk of the first prompt turn.
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const notice = 'pi v0.80.1\n---\n\n## Context\n- /home/u/.pi/agent/AGENTS.md'
+
+  // setStartupInfo mirrors what session/new does. Do NOT call sendStartupInfoIfPending()
+  // manually here -- that is exactly the out-of-turn call we removed.
+  session.setStartupInfo(notice)
+
+  // Drain microtasks: no update must have been emitted out-of-turn.
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(conn.updates.length, 0, 'startup info must not be emitted before a prompt turn')
+
+  // Starting the first prompt turn must flush the startup info as the very first
+  // agent_message_chunk, before any other turn update.
+  const p = session.prompt('hello')
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(proc.prompts.length, 1)
+  assert.equal(proc.prompts[0]!.message, 'hello')
+
+  assert.equal(conn.updates[0]!.update.sessionUpdate, 'agent_message_chunk')
+  assert.deepEqual((conn.updates[0]!.update as any).content, { type: 'text', text: notice })
+
+  // The startup info chunk must appear exactly once across the whole turn.
+  const startupChunks = conn.updates.filter(
+    entry =>
+      entry.update.sessionUpdate === 'agent_message_chunk' &&
+      (entry.update as any).content?.type === 'text' &&
+      (entry.update as any).content?.text === notice
+  )
+  assert.equal(startupChunks.length, 1)
+
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'turn_end' })
+  proc.emit({ type: 'agent_end' })
+
+  const reason = await p
+  assert.equal(reason, 'end_turn')
+})
+
 test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/unit/startup-info-env.test.ts
+++ b/test/unit/startup-info-env.test.ts
@@ -65,10 +65,13 @@ test('PiAcpAgent: quietStartup=true disables startup info generation/emission', 
     // When quietStartup=true the full prelude is suppressed. However, an update notice
     // (if one exists) is still surfaced because it's high-signal and actionable.
     // The test must tolerate both cases since the live npm check may or may not find an update.
+    // Only one setTimeout is ever scheduled now: the available_commands_update emit
+    // (sent after the session/new response). The startup banner is no longer emitted
+    // out-of-turn via setTimeout -- it is flushed in-turn on the first prompt (see #59).
     if (startupInfo) {
       assert.match(startupInfo, /New version available/)
       assert.equal(setStartupInfoCalled, true)
-      assert.equal(timeouts.length, 2)
+      assert.equal(timeouts.length, 1)
     } else {
       assert.equal(setStartupInfoCalled, false)
       assert.equal(timeouts.length, 1)


### PR DESCRIPTION
## Before

`pi-acp` emitted the startup banner (pi version + Context/Skills/Extensions) as an `agent_message_chunk` right after `session/new`, with no `session/prompt` active:

```ts
if (preludeText) setTimeout(() => session.sendStartupInfoIfPending(), 0)
```

Strict ACP clients reject this as an out-of-turn `session/update`:

> This session/update arrived after the turn ended, which violates the ACP protocol — per-turn updates must arrive while a `session/prompt` is active.

## After

The banner is flushed inside `startTurn()` as the first `agent_message_chunk` of the first prompt turn — protocol-legal. It's still returned via `_meta.piAcp.startupInfo` in the `session/new` response, so clients that render it themselves (Zed) are unaffected.

- Removed the out-of-turn `setTimeout` emit in `newSession`.
- `startTurn()` calls `sendStartupInfoIfPending()` first.
- Added regression test; updated `quietStartup` unit test's `setTimeout` count (`2 → 1`).

`npm test` (89 pass) · `lint` · `typecheck` · `build` all green.

Note: AI assisted, reviewed and tested by me.

Fixes #59.
