### PR TITLE
Update note about `/models` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Loaded from:
 
 Other built-in commands:
 
-- `/model` - maps to model selector in Zed
+- `/model` - not implemented (use the model selector UI in Zed)
 - `/thinking` - maps to 'mode' selector in Zed
 - `/clear` - not implemented (use ACP client 'new' command)
 


### PR DESCRIPTION
The previous note gave the impression that this slash command sholud work. However, it is not implemented because there is a nice UI built into Zed which allows you to select the model and there is no need to duplicate it.

Fixes #63