### PR TITLE
More descriptive tool call titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ Point your ACP client to the built `dist/index.js`:
 - `PI_ACP_ENABLE_EMBEDDED_CONTEXT=true` advertises ACP `promptCapabilities.embeddedContext` support to the client.
 - Default: unset/any other value means `false`.
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
+- `PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES=true` enables more descriptive ACP tool titles for file tools like `read`, `write`, and `edit`.
+- Default: unset/any other value means file tools keep their plain tool-name titles. Bash titles still show the command text.
 
-You can add the environment variable in the Zed settings with:
+You can add the environment variables in the Zed settings with:
 
 ```json
   "agent_servers": {
@@ -125,6 +127,7 @@ You can add the environment variable in the Zed settings with:
       "args": ["/path/to/pi-acp/dist/index.js"],
       "env": {
           "PI_ACP_ENABLE_EMBEDDED_CONTEXT": "true",
+          "PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES": "true"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Point your ACP client to the built `dist/index.js`:
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
 - `PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES=true` enables more descriptive ACP tool titles for file tools like `read`, `write`, and `edit`.
 - Default: unset/any other value means file tools keep their plain tool-name titles. Bash titles still show the command text.
+- `PI_ACP_BASH_MAX_OUTPUT_LINES=N` limits the number of bash output lines rendered in the client's terminal view to the last `N` lines, matching pi's native TUI behavior. The full output is always preserved in `rawOutput` for the model/session history.
+- Default: unset means all lines are streamed (existing behavior).
 
 You can add the environment variables in the Zed settings with:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Point your ACP client to the built `dist/index.js`:
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
 - `PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES=true` enables more descriptive ACP tool titles for file tools like `read`, `write`, and `edit`.
 - Default: unset/any other value means file tools keep their plain tool-name titles. Bash titles still show the command text.
-- `PI_ACP_BASH_MAX_OUTPUT_LINES=N` limits the number of bash output lines rendered in the client's terminal view to the last `N` lines, matching pi's native TUI behavior. The full output is always preserved in `rawOutput` for the model/session history.
+- `PI_ACP_BASH_MAX_OUTPUT_LINES=N` limits the number of bash output lines rendered in the client's terminal view to the last `N` lines for **live** tool calls, matching pi's native TUI behavior. The full output is always preserved in `rawOutput` for the model/session history. Resumed (`loadSession`) replays always render the full output.
 - Default: unset means all lines are streamed (existing behavior).
 
 You can add the environment variables in the Zed settings with:

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -31,12 +31,14 @@ import { toolResultToText } from './translate/pi-tools.js'
 import {
   bashCommand,
   bashExitCode,
+  bashMaxOutputLines,
   bashResultText,
   bashTerminalContent,
   bashTerminalExitMeta,
   bashTerminalInfoMeta,
   bashTerminalOutputMeta,
-  isBashTool
+  isBashTool,
+  truncateToLastLines
 } from './translate/bash.js'
 import { promptToPiMessage } from './translate/prompt.js'
 import { loadSlashCommands, parseCommandArgs, toAvailableCommands } from './slash-commands.js'
@@ -1002,6 +1004,7 @@ export class PiAcpAgent implements ACPAgent {
         if (isBash) {
           const text = bashResultText(m)
           const rawInput = (m as any)?.args ?? null
+          const displayText = truncateToLastLines(text, bashMaxOutputLines())
           await this.conn.sessionUpdate({
             sessionId: session.sessionId,
             update: {
@@ -1025,7 +1028,7 @@ export class PiAcpAgent implements ACPAgent {
               rawInput,
               rawOutput: m,
               _meta: {
-                ...(text ? bashTerminalOutputMeta(toolCallId, text) : {}),
+                ...(displayText ? bashTerminalOutputMeta(toolCallId, displayText) : {}),
                 ...bashTerminalExitMeta(toolCallId, bashExitCode(m, isError))
               }
             }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -1001,6 +1001,7 @@ export class PiAcpAgent implements ACPAgent {
 
         if (isBash) {
           const text = bashResultText(m)
+          const rawInput = (m as any)?.args ?? null
           await this.conn.sessionUpdate({
             sessionId: session.sessionId,
             update: {
@@ -1009,6 +1010,7 @@ export class PiAcpAgent implements ACPAgent {
               title: bashCommand(m) ?? toolName,
               kind: 'execute',
               status: 'completed',
+              rawInput,
               content: bashTerminalContent(toolCallId),
               _meta: bashTerminalInfoMeta(toolCallId, params.cwd)
             }
@@ -1020,6 +1022,8 @@ export class PiAcpAgent implements ACPAgent {
               sessionUpdate: 'tool_call_update',
               toolCallId,
               status: isError ? 'failed' : 'completed',
+              rawInput,
+              rawOutput: m,
               _meta: {
                 ...(text ? bashTerminalOutputMeta(toolCallId, text) : {}),
                 ...bashTerminalExitMeta(toolCallId, bashExitCode(m, isError))

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -22,7 +22,7 @@ import {
   type StopReason
 } from '@agentclientprotocol/sdk'
 import { getAuthMethods } from './auth.js'
-import { SessionManager, type PiAcpSession } from './session.js'
+import { SessionManager, type PiAcpSession, toToolCallLocations, toToolTitle } from './session.js'
 import { SessionStore } from './session-store.js'
 import { PiRpcProcess } from '../pi-rpc/process.js'
 import { listPiSessions, findPiSession } from './pi-sessions.js'
@@ -1034,15 +1034,19 @@ export class PiAcpAgent implements ACPAgent {
         }
 
         // Create a synthetic ACP tool call to render historic tool usage.
+        const rawInput = (m as any)?.args ?? null
+        const title = toToolTitle(toolName, rawInput, params.cwd)
+        const locations = toToolCallLocations(rawInput, params.cwd)
         await this.conn.sessionUpdate({
           sessionId: session.sessionId,
           update: {
             sessionUpdate: 'tool_call',
             toolCallId,
-            title: toolName,
+            title,
             kind: toolName === 'read' ? 'read' : toolName === 'write' || toolName === 'edit' ? 'edit' : 'other',
             status: 'completed',
-            rawInput: null,
+            rawInput,
+            locations,
             rawOutput: m
           }
         })

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -22,7 +22,7 @@ import {
   type StopReason
 } from '@agentclientprotocol/sdk'
 import { getAuthMethods } from './auth.js'
-import { SessionManager, type PiAcpSession, toToolCallLocations, toToolTitle } from './session.js'
+import { SessionManager, type PiAcpSession, toToolCallLocations, toReplayDiffContent, toToolTitle } from './session.js'
 import { SessionStore } from './session-store.js'
 import { PiRpcProcess } from '../pi-rpc/process.js'
 import { listPiSessions, findPiSession } from './pi-sessions.js'
@@ -31,7 +31,6 @@ import { toolResultToText } from './translate/pi-tools.js'
 import {
   bashCommand,
   bashExitCode,
-  bashMaxOutputLines,
   bashResultText,
   bashTerminalContent,
   bashTerminalExitMeta,
@@ -966,6 +965,10 @@ export class PiAcpAgent implements ACPAgent {
     const data = (await proc.getMessages()) as any
     const messages = Array.isArray(data?.messages) ? data.messages : []
 
+    // pi stores tool args on the assistant `toolCall` content block, not on the
+    // matching toolResult message. Index them by tool call id so historic
+    // tool results can recover their inputs for titles, locations, and rawInput.
+    const toolCallArgs = new Map<string, unknown>()
     for (const m of messages) {
       const role = String(m?.role ?? '')
 
@@ -983,6 +986,13 @@ export class PiAcpAgent implements ACPAgent {
       }
 
       if (role === 'assistant') {
+        if (Array.isArray(m?.content)) {
+          for (const block of m.content as Array<Record<string, unknown>>) {
+            if (block?.type === 'toolCall' && typeof block.id === 'string') {
+              toolCallArgs.set(block.id, block.arguments)
+            }
+          }
+        }
         const text = normalizePiAssistantText(m?.content)
         if (text) {
           await this.conn.sessionUpdate({
@@ -1000,17 +1010,16 @@ export class PiAcpAgent implements ACPAgent {
         const toolCallId = String((m as any)?.toolCallId ?? crypto.randomUUID())
         const isError = Boolean((m as any)?.isError)
         const isBash = isBashTool(toolName)
+        const rawInput = (m as any)?.args ?? toolCallArgs.get(toolCallId) ?? null
 
         if (isBash) {
           const text = bashResultText(m)
-          const rawInput = (m as any)?.args ?? null
-          const displayText = truncateToLastLines(text, bashMaxOutputLines())
           await this.conn.sessionUpdate({
             sessionId: session.sessionId,
             update: {
               sessionUpdate: 'tool_call',
               toolCallId,
-              title: bashCommand(m) ?? toolName,
+              title: bashCommand(rawInput) ?? toolName,
               kind: 'execute',
               status: 'completed',
               rawInput,
@@ -1028,7 +1037,7 @@ export class PiAcpAgent implements ACPAgent {
               rawInput,
               rawOutput: m,
               _meta: {
-                ...(displayText ? bashTerminalOutputMeta(toolCallId, displayText) : {}),
+                ...(text ? bashTerminalOutputMeta(toolCallId, text) : {}),
                 ...bashTerminalExitMeta(toolCallId, bashExitCode(m, isError))
               }
             }
@@ -1037,7 +1046,6 @@ export class PiAcpAgent implements ACPAgent {
         }
 
         // Create a synthetic ACP tool call to render historic tool usage.
-        const rawInput = (m as any)?.args ?? null
         const title = toToolTitle(toolName, rawInput, params.cwd)
         const locations = toToolCallLocations(rawInput, params.cwd)
         await this.conn.sessionUpdate({
@@ -1054,15 +1062,17 @@ export class PiAcpAgent implements ACPAgent {
           }
         })
 
+        const diffContent = toReplayDiffContent(toolName, rawInput)
         const text = toolResultToText(m)
+        const content = diffContent ?? (text ? [{ type: 'content', content: { type: 'text', text } }] : null)
         await this.conn.sessionUpdate({
           sessionId: session.sessionId,
           update: {
             sessionUpdate: 'tool_call_update',
             toolCallId,
             status: isError ? 'failed' : 'completed',
-            content: text ? [{ type: 'content', content: { type: 'text', text } }] : null,
-            rawOutput: m
+            content,
+            ...(diffContent ? {} : { rawOutput: m })
           }
         })
       }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -139,12 +139,58 @@ function getEditOldTexts(args: unknown): string[] {
   return oldTexts
 }
 
-function toToolCallLocations(args: unknown, cwd: string, line?: number): ToolCallLocation[] | undefined {
+export function toToolCallLocations(args: unknown, cwd: string, line?: number): ToolCallLocation[] | undefined {
   const path = getToolPath(args)
   if (!path) return undefined
 
   const resolvedPath = isAbsolute(path) ? path : resolvePath(cwd, path)
   return [{ path: resolvedPath, ...(typeof line === 'number' ? { line } : {}) }]
+}
+
+export const PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = 'PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES'
+
+function toDisplayPath(path: string, cwd: string): string {
+  const resolved = isAbsolute(path) ? path : resolvePath(cwd, path)
+  return resolved.startsWith(cwd + '/') ? resolved.slice(cwd.length + 1) : resolved
+}
+
+function descriptiveToolTitlesEnabled(): boolean {
+  return process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES === 'true'
+}
+
+export function toToolTitle(toolName: string, args: unknown, cwd: string): string {
+  const lower = toolName.toLowerCase()
+
+  if (lower === 'bash') {
+    return bashCommand(args) ?? toolName
+  }
+
+  if (!descriptiveToolTitlesEnabled()) {
+    return toolName
+  }
+
+  const path = getToolPath(args)
+  const displayPath = path ? toDisplayPath(path, cwd) : undefined
+
+  if (lower === 'read') {
+    const record = args as { offset?: unknown; limit?: unknown } | null | undefined
+    const offset = typeof record?.offset === 'number' ? record.offset : undefined
+    const limit = typeof record?.limit === 'number' && record.limit > 0 ? record.limit : undefined
+    let range = ''
+    if (offset !== undefined && limit !== undefined) range = ` (${offset} - ${offset + limit - 1})`
+    else if (offset !== undefined) range = ` (from line ${offset})`
+    return displayPath ? `Read ${displayPath}${range}` : 'Read'
+  }
+
+  if (lower === 'write') {
+    return displayPath ? `Write ${displayPath}` : 'Write'
+  }
+
+  if (lower === 'edit') {
+    return displayPath ? `Edit ${displayPath}` : 'Edit'
+  }
+
+  return toolName
 }
 
 export class SessionManager {
@@ -458,9 +504,7 @@ export class PiAcpSession {
       toolCallId: params.toolCallId,
       status: params.status,
       rawInput,
-      ...(params.status === 'completed' || params.status === 'failed'
-        ? { rawOutput: params.result }
-        : {}),
+      ...(params.status === 'completed' || params.status === 'failed' ? { rawOutput: params.result } : {}),
       _meta: {
         ...(delta ? bashTerminalOutputMeta(params.toolCallId, delta) : {}),
         ...(params.status === 'completed' || params.status === 'failed'
@@ -571,12 +615,12 @@ export class PiAcpSession {
                     }
                   })()
 
-            const locations = toToolCallLocations(rawInput, this.cwd)
             const existingStatus = this.currentToolCalls.get(toolCallId)
             // IMPORTANT: never downgrade status (e.g. if we already marked in_progress via tool_execution_start).
             const status = existingStatus ?? 'pending'
 
             if (isBashTool(toolName)) {
+              const locations = toToolCallLocations(rawInput, this.cwd)
               if (!existingStatus) this.currentToolCalls.set(toolCallId, 'pending')
               this.emitBashToolCall({
                 sessionUpdate: existingStatus ? 'tool_call_update' : 'tool_call',
@@ -595,17 +639,18 @@ export class PiAcpSession {
                 title: toolName,
                 kind: toToolKind(toolName),
                 status,
-                locations,
+                locations: [],
                 rawInput
               })
             } else {
               // Best-effort: keep rawInput updated while args are streaming.
-              // Keep the existing status (pending or in_progress).
+              // Don't emit locations here because pi streams partial args and
+              // partial paths (e.g. /tmp -> /tmp/test -> ...) confuse clients
+              // like Zed. The final locations are sent at tool_execution_start.
               this.emit({
                 sessionUpdate: 'tool_call_update',
                 toolCallId,
                 status,
-                locations,
                 rawInput
               })
             }
@@ -667,13 +712,15 @@ export class PiAcpSession {
 
         const locations = toToolCallLocations(args, this.cwd, line)
 
+        const title = toToolTitle(toolName, args, this.cwd)
+
         // If we already surfaced the tool call while the model streamed it, just transition.
         if (!this.currentToolCalls.has(toolCallId)) {
           this.currentToolCalls.set(toolCallId, 'in_progress')
           this.emit({
             sessionUpdate: 'tool_call',
             toolCallId,
-            title: toolName,
+            title,
             kind: toToolKind(toolName),
             status: 'in_progress',
             locations,
@@ -684,6 +731,7 @@ export class PiAcpSession {
           this.emit({
             sessionUpdate: 'tool_call_update',
             toolCallId,
+            title,
             status: 'in_progress',
             locations,
             rawInput: args

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -195,6 +195,35 @@ export function toToolTitle(toolName: string, args: unknown, cwd: string): strin
   return toolName
 }
 
+// Reconstruct structured ACP diff content for historic edit/write tool results.
+// Unlike the live path (which snapshots pre-mutation file contents), replay
+// only has the tool args: edit carries {oldText,newText} snippets, write carries
+// the full new content. Pre-mutation contents are unrecoverable, so historic
+// writes render as new-file diffs.
+export function toReplayDiffContent(toolName: string, args: unknown): ToolCallContent[] | undefined {
+  const lower = toolName.toLowerCase()
+  const path = getToolPath(args)
+  if (!path) return undefined
+
+  if (lower === 'write') {
+    const content = (args as { content?: unknown } | null | undefined)?.content
+    if (typeof content === 'string') {
+      return [{ type: 'diff', path, oldText: null, newText: content }]
+    }
+    return undefined
+  }
+
+  if (lower === 'edit') {
+    const edits = getParsedEdits(args)
+    if (edits.length) {
+      return edits.map(edit => ({ type: 'diff', path, oldText: edit.oldText, newText: edit.newText }))
+    }
+    return undefined
+  }
+
+  return undefined
+}
+
 export class SessionManager {
   private sessions = new Map<string, PiAcpSession>()
   private readonly store = new SessionStore()

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -18,13 +18,15 @@ import { expandSlashCommand, type FileSlashCommand } from './slash-commands.js'
 import {
   bashCommand,
   bashExitCode,
+  bashMaxOutputLines,
   bashOutputDelta,
   bashResultText,
   bashTerminalContent,
   bashTerminalExitMeta,
   bashTerminalInfoMeta,
   bashTerminalOutputMeta,
-  isBashTool
+  isBashTool,
+  truncateToLastLines
 } from './translate/bash.js'
 import { toolResultToText } from './translate/pi-tools.js'
 
@@ -494,11 +496,33 @@ export class PiAcpSession {
     isError?: boolean
   }): void {
     const text = bashResultText(params.result)
+    const rawInput = this.bashRawInputs.get(params.toolCallId)
+    const maxLines = bashMaxOutputLines()
+
+    if (maxLines != null) {
+      // Tail-truncate mode: buffer output and only emit the final tail on
+      // completion. ACP terminal_output is append-only, so we cannot stream
+      // live and later hide earlier lines.
+      if (params.status === 'completed' || params.status === 'failed') {
+        const displayText = truncateToLastLines(text, maxLines)
+        this.emit({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: params.toolCallId,
+          status: params.status,
+          rawInput,
+          rawOutput: params.result,
+          _meta: {
+            ...(displayText ? bashTerminalOutputMeta(params.toolCallId, displayText) : {}),
+            ...bashTerminalExitMeta(params.toolCallId, bashExitCode(params.result, Boolean(params.isError)))
+          }
+        })
+      }
+      return
+    }
+
     const previous = this.bashOutputSnapshots.get(params.toolCallId) ?? ''
     const delta = bashOutputDelta(previous, text)
     this.bashOutputSnapshots.set(params.toolCallId, text)
-    const rawInput = this.bashRawInputs.get(params.toolCallId)
-
     this.emit({
       sessionUpdate: 'tool_call_update',
       toolCallId: params.toolCallId,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -290,6 +290,7 @@ export class PiAcpSession {
   private fileMutationToolCallIds = new Set<string>()
   private bashToolCallIds = new Set<string>()
   private bashOutputSnapshots = new Map<string, string>()
+  private bashRawInputs = new Map<string, unknown>()
 
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
@@ -426,6 +427,7 @@ export class PiAcpSession {
     includeTerminal: boolean
   }): void {
     this.bashToolCallIds.add(params.toolCallId)
+    this.bashRawInputs.set(params.toolCallId, params.args)
     this.emit({
       sessionUpdate: params.sessionUpdate,
       toolCallId: params.toolCallId,
@@ -433,6 +435,7 @@ export class PiAcpSession {
       kind: 'execute',
       status: params.status,
       locations: params.locations,
+      rawInput: params.args,
       ...(params.includeTerminal ? { content: bashTerminalContent(params.toolCallId) } : {}),
       ...(params.includeTerminal ? { _meta: bashTerminalInfoMeta(params.toolCallId, this.cwd) } : {})
     })
@@ -448,11 +451,16 @@ export class PiAcpSession {
     const previous = this.bashOutputSnapshots.get(params.toolCallId) ?? ''
     const delta = bashOutputDelta(previous, text)
     this.bashOutputSnapshots.set(params.toolCallId, text)
+    const rawInput = this.bashRawInputs.get(params.toolCallId)
 
     this.emit({
       sessionUpdate: 'tool_call_update',
       toolCallId: params.toolCallId,
       status: params.status,
+      rawInput,
+      ...(params.status === 'completed' || params.status === 'failed'
+        ? { rawOutput: params.result }
+        : {}),
       _meta: {
         ...(delta ? bashTerminalOutputMeta(params.toolCallId, delta) : {}),
         ...(params.status === 'completed' || params.status === 'failed'
@@ -468,6 +476,7 @@ export class PiAcpSession {
     this.fileMutationToolCallIds.delete(toolCallId)
     this.bashToolCallIds.delete(toolCallId)
     this.bashOutputSnapshots.delete(toolCallId)
+    this.bashRawInputs.delete(toolCallId)
   }
 
   private startTurn(t: QueuedTurn): void {

--- a/src/acp/translate/bash.ts
+++ b/src/acp/translate/bash.ts
@@ -80,6 +80,27 @@ export function bashOutputDelta(previous: string, next: string): string {
   return next.startsWith(previous) ? next.slice(previous.length) : next
 }
 
+export function bashMaxOutputLines(): number | undefined {
+  const value = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  if (value == null || value === '') return undefined
+  const parsed = Number(value)
+  return Number.isNaN(parsed) || parsed <= 0 ? undefined : parsed
+}
+
+export function truncateToLastLines(text: string, maxLines?: number): string {
+  if (maxLines == null || maxLines <= 0) return text
+
+  const hasTrailingNewline = text.endsWith('\n')
+  const trimmed = hasTrailingNewline ? text.slice(0, -1) : text
+  const lines = trimmed.split('\n')
+
+  if (lines.length <= maxLines) return text
+
+  const skipped = lines.length - maxLines
+  const tail = lines.slice(-maxLines).join('\n')
+  return `... (${skipped} earlier lines truncated)\n${tail}${hasTrailingNewline ? '\n' : ''}`
+}
+
 export function bashTerminalContent(toolCallId: string): ToolCallContent[] {
   return [{ type: 'terminal', terminalId: toolCallId }] satisfies ToolCallContent[]
 }

--- a/test/component/bash-truncation.test.ts
+++ b/test/component/bash-truncation.test.ts
@@ -1,0 +1,69 @@
+import test, { afterEach, beforeEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+// This test mutates process.env.PI_ACP_BASH_MAX_OUTPUT_LINES. session.ts reads
+// the env var from a deferred-microtask emit chain, so a concurrent test whose
+// body sets the var can interleave with this one's deferred reads. Keeping it
+// in its own process (each test file runs in a separate node:test process)
+// avoids perturbing suites that assert the default streaming behavior.
+describe('bash output truncation', { concurrency: 1 }, () => {
+  beforeEach(() => {
+    process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '2'
+  })
+
+  afterEach(() => {
+    delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  })
+
+  test('PiAcpSession: tail-truncates live bash terminal output', async () => {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+
+    new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    proc.emit({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'bash', args: { command: 'seq 1 5' } })
+    proc.emit({
+      type: 'tool_execution_update',
+      toolCallId: 't1',
+      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n' }] }
+    })
+    proc.emit({
+      type: 'tool_execution_update',
+      toolCallId: 't1',
+      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n4\n' }] }
+    })
+    proc.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      isError: false,
+      result: { content: [{ type: 'text', text: '1\n2\n3\n4\n5' }] }
+    })
+
+    await new Promise(r => setTimeout(r, 0))
+
+    const intermediateUpdates = conn.updates.filter(
+      u => u.update.sessionUpdate === 'tool_call_update' && (u.update as any).status === 'in_progress'
+    )
+    assert.equal(intermediateUpdates.length, 0, 'tail-truncate mode should not emit intermediate terminal_output')
+
+    const completed = conn.updates.find(u => (u.update as any).status === 'completed')
+    assert.ok(completed)
+    assert.deepEqual((completed!.update as any)._meta.terminal_output, {
+      terminal_id: 't1',
+      data: '... (3 earlier lines truncated)\n4\n5'
+    })
+    assert.deepEqual((completed!.update as any).rawOutput, {
+      content: [{ type: 'text', text: '1\n2\n3\n4\n5' }]
+    })
+  })
+})

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -102,12 +102,13 @@ test('PiAcpSession: emits tool_call + tool_call_update + completes', async () =>
   assert.deepEqual((conn.updates[0]!.update as any)._meta, {
     terminal_info: { terminal_id: 't1', cwd: process.cwd() }
   })
-  assert.equal((conn.updates[0]!.update as any).rawInput, undefined)
+  assert.deepEqual((conn.updates[0]!.update as any).rawInput, { command: 'ls' })
 
   assert.equal(conn.updates[1]!.update.sessionUpdate, 'tool_call_update')
   assert.equal((conn.updates[1]!.update as any).toolCallId, 't1')
   assert.equal((conn.updates[1]!.update as any).status, 'in_progress')
   assert.equal((conn.updates[1]!.update as any).content, undefined)
+  assert.deepEqual((conn.updates[1]!.update as any).rawInput, { command: 'ls' })
   assert.deepEqual((conn.updates[1]!.update as any)._meta, {
     terminal_output: { terminal_id: 't1', data: 'running' }
   })
@@ -117,11 +118,14 @@ test('PiAcpSession: emits tool_call + tool_call_update + completes', async () =>
   assert.equal((conn.updates[2]!.update as any).toolCallId, 't1')
   assert.equal((conn.updates[2]!.update as any).status, 'completed')
   assert.equal((conn.updates[2]!.update as any).content, undefined)
+  assert.deepEqual((conn.updates[2]!.update as any).rawInput, { command: 'ls' })
+  assert.deepEqual((conn.updates[2]!.update as any).rawOutput, {
+    content: [{ type: 'text', text: 'done' }]
+  })
   assert.deepEqual((conn.updates[2]!.update as any)._meta, {
     terminal_output: { terminal_id: 't1', data: 'done' },
     terminal_exit: { terminal_id: 't1', exit_code: 0, signal: null }
   })
-  assert.equal((conn.updates[2]!.update as any).rawOutput, undefined)
 })
 
 test('PiAcpSession: emits tool locations from pi path args', async () => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -480,36 +480,103 @@ test('PiAcpSession: preserves ordering when auto_retry_start is interleaved with
   )
 })
 
-test('PiAcpSession: emits streamed tool locations from pi path args', async () => {
+test('PiAcpSession: emits tool locations at execution start', async () => {
+  const previous = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
-  new PiAcpSession({
-    sessionId: 's1',
-    cwd: process.cwd(),
-    mcpServers: [],
-    proc: proc as any,
-    conn: asAgentConn(conn),
-    fileCommands: []
-  })
+  try {
+    new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
 
-  proc.emit({
-    type: 'message_update',
-    assistantMessageEvent: {
-      type: 'toolcall_start',
-      toolCall: {
-        id: 't1',
-        name: 'write',
-        arguments: { path: '/tmp/test.txt', content: 'hello' }
+    proc.emit({
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'toolcall_start',
+        toolCall: {
+          id: 't1',
+          name: 'write',
+          arguments: { path: '/tmp/test.txt', content: 'hello' }
+        }
       }
-    }
-  })
+    })
+    proc.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'write',
+      args: { path: '/tmp/test.txt', content: 'hello' }
+    })
 
-  await new Promise(r => setTimeout(r, 0))
+    await new Promise(r => setTimeout(r, 0))
 
-  assert.equal(conn.updates.length, 1)
-  assert.equal(conn.updates[0]!.update.sessionUpdate, 'tool_call')
-  assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: '/tmp/test.txt' }])
+    const update = conn.updates.find(u => u.update.sessionUpdate === 'tool_call_update')
+    assert.ok(update)
+    assert.equal((update!.update as any).toolCallId, 't1')
+    assert.equal((update!.update as any).status, 'in_progress')
+    assert.equal((update!.update as any).title, 'write')
+    assert.deepEqual((update!.update as any).locations, [{ path: '/tmp/test.txt' }])
+  } finally {
+    if (previous === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previous
+  }
+})
+
+test('PiAcpSession: can emit descriptive tool titles at execution start', async () => {
+  const previous = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = 'true'
+
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  try {
+    new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    proc.emit({
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'toolcall_start',
+        toolCall: {
+          id: 't2',
+          name: 'write',
+          arguments: { path: '/tmp/test.txt', content: 'hello' }
+        }
+      }
+    })
+    proc.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't2',
+      toolName: 'write',
+      args: { path: '/tmp/test.txt', content: 'hello' }
+    })
+
+    await new Promise(r => setTimeout(r, 0))
+
+    const update = conn.updates.find(
+      u => (u.update as any).toolCallId === 't2' && u.update.sessionUpdate === 'tool_call_update'
+    )
+    assert.ok(update)
+    assert.equal((update!.update as any).status, 'in_progress')
+    assert.equal((update!.update as any).title, 'Write /tmp/test.txt')
+    assert.deepEqual((update!.update as any).locations, [{ path: '/tmp/test.txt' }])
+  } finally {
+    if (previous === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previous
+  }
 })
 
 test('PiAcpSession: emits edit tool line when oldText matches uniquely', async () => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -1,10 +1,22 @@
-import test from 'node:test'
+import test, { afterEach, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PiAcpSession } from '../../src/acp/session.js'
 import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+// Neutralize inherited PI_ACP_BASH_MAX_OUTPUT_LINES so tests that assert the
+// default streaming behavior aren't affected by the runtime environment.
+let previousBashMax: string | undefined
+beforeEach(() => {
+  previousBashMax = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+})
+afterEach(() => {
+  if (previousBashMax === undefined) delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  else process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = previousBashMax
+})
 
 test('PiAcpSession: emits agent_message_chunk for text_delta', async () => {
   const conn = new FakeAgentSideConnection()
@@ -126,63 +138,6 @@ test('PiAcpSession: emits tool_call + tool_call_update + completes', async () =>
     terminal_output: { terminal_id: 't1', data: 'done' },
     terminal_exit: { terminal_id: 't1', exit_code: 0, signal: null }
   })
-})
-
-test('PiAcpSession: tail-truncates bash terminal output when PI_ACP_BASH_MAX_OUTPUT_LINES is set', async () => {
-  const previous = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
-  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '2'
-
-  const conn = new FakeAgentSideConnection()
-  const proc = new FakePiRpcProcess()
-
-  try {
-    new PiAcpSession({
-      sessionId: 's1',
-      cwd: process.cwd(),
-      mcpServers: [],
-      proc: proc as any,
-      conn: asAgentConn(conn),
-      fileCommands: []
-    })
-
-    proc.emit({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'bash', args: { command: 'seq 1 5' } })
-    proc.emit({
-      type: 'tool_execution_update',
-      toolCallId: 't1',
-      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n' }] }
-    })
-    proc.emit({
-      type: 'tool_execution_update',
-      toolCallId: 't1',
-      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n4\n' }] }
-    })
-    proc.emit({
-      type: 'tool_execution_end',
-      toolCallId: 't1',
-      isError: false,
-      result: { content: [{ type: 'text', text: '1\n2\n3\n4\n5' }] }
-    })
-
-    await new Promise(r => setTimeout(r, 0))
-
-    const intermediateUpdates = conn.updates.filter(
-      u => u.update.sessionUpdate === 'tool_call_update' && (u.update as any).status === 'in_progress'
-    )
-    assert.equal(intermediateUpdates.length, 0, 'tail-truncate mode should not emit intermediate terminal_output')
-
-    const completed = conn.updates.find(u => (u.update as any).status === 'completed')
-    assert.ok(completed)
-    assert.deepEqual((completed!.update as any)._meta.terminal_output, {
-      terminal_id: 't1',
-      data: '... (3 earlier lines truncated)\n4\n5'
-    })
-    assert.deepEqual((completed!.update as any).rawOutput, {
-      content: [{ type: 'text', text: '1\n2\n3\n4\n5' }]
-    })
-  } finally {
-    if (previous === undefined) delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
-    else process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = previous
-  }
 })
 
 test('PiAcpSession: emits tool locations from pi path args', async () => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -128,6 +128,63 @@ test('PiAcpSession: emits tool_call + tool_call_update + completes', async () =>
   })
 })
 
+test('PiAcpSession: tail-truncates bash terminal output when PI_ACP_BASH_MAX_OUTPUT_LINES is set', async () => {
+  const previous = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '2'
+
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  try {
+    new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    proc.emit({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'bash', args: { command: 'seq 1 5' } })
+    proc.emit({
+      type: 'tool_execution_update',
+      toolCallId: 't1',
+      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n' }] }
+    })
+    proc.emit({
+      type: 'tool_execution_update',
+      toolCallId: 't1',
+      partialResult: { content: [{ type: 'text', text: '1\n2\n3\n4\n' }] }
+    })
+    proc.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      isError: false,
+      result: { content: [{ type: 'text', text: '1\n2\n3\n4\n5' }] }
+    })
+
+    await new Promise(r => setTimeout(r, 0))
+
+    const intermediateUpdates = conn.updates.filter(
+      u => u.update.sessionUpdate === 'tool_call_update' && (u.update as any).status === 'in_progress'
+    )
+    assert.equal(intermediateUpdates.length, 0, 'tail-truncate mode should not emit intermediate terminal_output')
+
+    const completed = conn.updates.find(u => (u.update as any).status === 'completed')
+    assert.ok(completed)
+    assert.deepEqual((completed!.update as any)._meta.terminal_output, {
+      terminal_id: 't1',
+      data: '... (3 earlier lines truncated)\n4\n5'
+    })
+    assert.deepEqual((completed!.update as any).rawOutput, {
+      content: [{ type: 'text', text: '1\n2\n3\n4\n5' }]
+    })
+  } finally {
+    if (previous === undefined) delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+    else process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = previous
+  }
+})
+
 test('PiAcpSession: emits tool locations from pi path args', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/component/session-load-toolresult.test.ts
+++ b/test/component/session-load-toolresult.test.ts
@@ -74,3 +74,118 @@ test('PiAcpAgent: loadSession replays toolResult as tool_call + tool_call_update
     PiRpcProcess.spawn = originalSpawn
   }
 })
+
+test('PiAcpAgent: loadSession replays read toolResult with locations and plain title by default', async () => {
+  const originalSpawn = PiRpcProcess.spawn
+  const previous = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  ;(PiRpcProcess as any).spawn = async () => {
+    return {
+      onEvent: () => () => {},
+      getMessages: async () => ({
+        messages: [
+          {
+            role: 'toolResult',
+            toolCallId: 'call_2',
+            toolName: 'read',
+            args: { path: '/tmp/project/src/main.ts' },
+            content: [{ type: 'text', text: 'export const x = 1' }],
+            isError: false
+          }
+        ]
+      }),
+      getAvailableModels: async () => ({ models: [] }),
+      getState: async () => ({ thinkingLevel: 'medium' })
+    } as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn))
+    ;(agent as any).store = new FakeStore()
+
+    await agent.loadSession({ sessionId: 's1', cwd: '/tmp/project', mcpServers: [] } as any)
+
+    const updates = conn.updates.map(u => (u as any).update)
+
+    const toolCall = updates.find(u => u?.sessionUpdate === 'tool_call')
+    assert.ok(toolCall)
+    assert.equal(toolCall.toolCallId, 'call_2')
+    assert.equal(toolCall.title, 'read')
+    assert.equal(toolCall.kind, 'read')
+    assert.deepEqual(toolCall.rawInput, { path: '/tmp/project/src/main.ts' })
+    assert.deepEqual(toolCall.locations, [{ path: '/tmp/project/src/main.ts' }])
+    assert.deepEqual(toolCall.rawOutput, {
+      role: 'toolResult',
+      toolCallId: 'call_2',
+      toolName: 'read',
+      args: { path: '/tmp/project/src/main.ts' },
+      content: [{ type: 'text', text: 'export const x = 1' }],
+      isError: false
+    })
+
+    const toolCallUpdate = updates.find(u => u?.sessionUpdate === 'tool_call_update')
+    assert.ok(toolCallUpdate)
+    assert.equal(toolCallUpdate.toolCallId, 'call_2')
+    assert.equal(toolCallUpdate.status, 'completed')
+    assert.deepEqual(toolCallUpdate.content, [
+      { type: 'content', content: { type: 'text', text: 'export const x = 1' } }
+    ])
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+    if (previous === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previous
+  }
+})
+
+test('PiAcpAgent: loadSession replays read toolResult with locations and descriptive title when enabled', async () => {
+  const originalSpawn = PiRpcProcess.spawn
+  const previous = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = 'true'
+  ;(PiRpcProcess as any).spawn = async () => {
+    return {
+      onEvent: () => () => {},
+      getMessages: async () => ({
+        messages: [
+          {
+            role: 'toolResult',
+            toolCallId: 'call_3',
+            toolName: 'read',
+            args: { path: '/tmp/project/src/main.ts' },
+            content: [{ type: 'text', text: 'export const x = 1' }],
+            isError: false
+          }
+        ]
+      }),
+      getAvailableModels: async () => ({ models: [] }),
+      getState: async () => ({ thinkingLevel: 'medium' })
+    } as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn))
+    ;(agent as any).store = new FakeStore()
+
+    await agent.loadSession({ sessionId: 's1', cwd: '/tmp/project', mcpServers: [] } as any)
+
+    const updates = conn.updates.map(u => (u as any).update)
+
+    const toolCall = updates.find(u => u?.sessionUpdate === 'tool_call')
+    assert.ok(toolCall)
+    assert.equal(toolCall.toolCallId, 'call_3')
+    assert.equal(toolCall.title, 'Read src/main.ts')
+    assert.equal(toolCall.kind, 'read')
+    assert.deepEqual(toolCall.rawInput, { path: '/tmp/project/src/main.ts' })
+    assert.deepEqual(toolCall.locations, [{ path: '/tmp/project/src/main.ts' }])
+
+    const toolCallUpdate = updates.find(u => u?.sessionUpdate === 'tool_call_update')
+    assert.ok(toolCallUpdate)
+    assert.equal(toolCallUpdate.toolCallId, 'call_3')
+    assert.equal(toolCallUpdate.status, 'completed')
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+    if (previous === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previous
+  }
+})

--- a/test/component/session-load-toolresult.test.ts
+++ b/test/component/session-load-toolresult.test.ts
@@ -50,17 +50,26 @@ test('PiAcpAgent: loadSession replays toolResult as tool_call + tool_call_update
     assert.equal(toolCall.kind, 'execute')
     assert.deepEqual(toolCall.content, [{ type: 'terminal', terminalId: 'call_1' }])
     assert.deepEqual(toolCall._meta, { terminal_info: { terminal_id: 'call_1', cwd: '/tmp/project' } })
+    assert.deepEqual(toolCall.rawInput, { command: 'echo hello' })
     assert.equal(toolCall.rawOutput, undefined)
 
     const toolCallUpdate = updates.find(u => u?.sessionUpdate === 'tool_call_update')
     assert.ok(toolCallUpdate)
     assert.equal(toolCallUpdate.toolCallId, 'call_1')
     assert.equal(toolCallUpdate.status, 'completed')
+    assert.deepEqual(toolCallUpdate.rawInput, { command: 'echo hello' })
+    assert.deepEqual(toolCallUpdate.rawOutput, {
+      role: 'toolResult',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      args: { command: 'echo hello' },
+      content: [{ type: 'text', text: 'hello from bash' }],
+      isError: false
+    })
     assert.deepEqual(toolCallUpdate._meta, {
       terminal_output: { terminal_id: 'call_1', data: 'hello from bash' },
       terminal_exit: { terminal_id: 'call_1', exit_code: 0, signal: null }
     })
-    assert.equal(toolCallUpdate.rawOutput, undefined)
   } finally {
     PiRpcProcess.spawn = originalSpawn
   }

--- a/test/component/session-load-toolresult.test.ts
+++ b/test/component/session-load-toolresult.test.ts
@@ -189,3 +189,58 @@ test('PiAcpAgent: loadSession replays read toolResult with locations and descrip
     else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previous
   }
 })
+
+test('PiAcpAgent: loadSession tail-truncates bash output when PI_ACP_BASH_MAX_OUTPUT_LINES is set', async () => {
+  const originalSpawn = PiRpcProcess.spawn
+  const previous = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '2'
+  ;(PiRpcProcess as any).spawn = async () => {
+    return {
+      onEvent: () => () => {},
+      getMessages: async () => ({
+        messages: [
+          {
+            role: 'toolResult',
+            toolCallId: 'call_4',
+            toolName: 'bash',
+            args: { command: 'seq 1 5' },
+            content: [{ type: 'text', text: '1\n2\n3\n4\n5' }],
+            isError: false
+          }
+        ]
+      }),
+      getAvailableModels: async () => ({ models: [] }),
+      getState: async () => ({ thinkingLevel: 'medium' })
+    } as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn))
+    ;(agent as any).store = new FakeStore()
+
+    await agent.loadSession({ sessionId: 's1', cwd: '/tmp/project', mcpServers: [] } as any)
+
+    const updates = conn.updates.map(u => (u as any).update)
+
+    const toolCallUpdate = updates.find(u => u?.sessionUpdate === 'tool_call_update')
+    assert.ok(toolCallUpdate)
+    assert.equal(toolCallUpdate.toolCallId, 'call_4')
+    assert.deepEqual(toolCallUpdate._meta.terminal_output, {
+      terminal_id: 'call_4',
+      data: '... (3 earlier lines truncated)\n4\n5'
+    })
+    assert.deepEqual(toolCallUpdate.rawOutput, {
+      role: 'toolResult',
+      toolCallId: 'call_4',
+      toolName: 'bash',
+      args: { command: 'seq 1 5' },
+      content: [{ type: 'text', text: '1\n2\n3\n4\n5' }],
+      isError: false
+    })
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+    if (previous === undefined) delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+    else process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = previous
+  }
+})

--- a/test/component/session-load-toolresult.test.ts
+++ b/test/component/session-load-toolresult.test.ts
@@ -190,21 +190,35 @@ test('PiAcpAgent: loadSession replays read toolResult with locations and descrip
   }
 })
 
-test('PiAcpAgent: loadSession tail-truncates bash output when PI_ACP_BASH_MAX_OUTPUT_LINES is set', async () => {
+test('PiAcpAgent: loadSession recovers tool args from the assistant toolCall block', async () => {
   const originalSpawn = PiRpcProcess.spawn
-  const previous = process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
-  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '2'
+  const previousTitles = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
   ;(PiRpcProcess as any).spawn = async () => {
     return {
       onEvent: () => () => {},
       getMessages: async () => ({
         messages: [
           {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: 'Running checks' },
+              { type: 'toolCall', id: 'call_b', name: 'bash', arguments: { command: 'rg foo src/' } },
+              { type: 'toolCall', id: 'call_r', name: 'read', arguments: { path: '/tmp/project/src/a.ts' } }
+            ]
+          },
+          {
             role: 'toolResult',
-            toolCallId: 'call_4',
+            toolCallId: 'call_b',
             toolName: 'bash',
-            args: { command: 'seq 1 5' },
-            content: [{ type: 'text', text: '1\n2\n3\n4\n5' }],
+            content: [{ type: 'text', text: 'src/a.ts:1:foo' }],
+            isError: false
+          },
+          {
+            role: 'toolResult',
+            toolCallId: 'call_r',
+            toolName: 'read',
+            content: [{ type: 'text', text: 'file contents' }],
             isError: false
           }
         ]
@@ -223,24 +237,124 @@ test('PiAcpAgent: loadSession tail-truncates bash output when PI_ACP_BASH_MAX_OU
 
     const updates = conn.updates.map(u => (u as any).update)
 
-    const toolCallUpdate = updates.find(u => u?.sessionUpdate === 'tool_call_update')
-    assert.ok(toolCallUpdate)
-    assert.equal(toolCallUpdate.toolCallId, 'call_4')
-    assert.deepEqual(toolCallUpdate._meta.terminal_output, {
-      terminal_id: 'call_4',
-      data: '... (3 earlier lines truncated)\n4\n5'
-    })
-    assert.deepEqual(toolCallUpdate.rawOutput, {
-      role: 'toolResult',
-      toolCallId: 'call_4',
-      toolName: 'bash',
-      args: { command: 'seq 1 5' },
-      content: [{ type: 'text', text: '1\n2\n3\n4\n5' }],
-      isError: false
-    })
+    const bashCall = updates.find(u => u?.sessionUpdate === 'tool_call' && u?.toolCallId === 'call_b')
+    assert.ok(bashCall)
+    assert.equal(bashCall.title, 'rg foo src/')
+    assert.deepEqual(bashCall.rawInput, { command: 'rg foo src/' })
+
+    const readCall = updates.find(u => u?.sessionUpdate === 'tool_call' && u?.toolCallId === 'call_r')
+    assert.ok(readCall)
+    assert.equal(readCall.title, 'read')
+    assert.deepEqual(readCall.rawInput, { path: '/tmp/project/src/a.ts' })
+    assert.deepEqual(readCall.locations, [{ path: '/tmp/project/src/a.ts' }])
   } finally {
     PiRpcProcess.spawn = originalSpawn
-    if (previous === undefined) delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
-    else process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = previous
+    if (previousTitles === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previousTitles
+  }
+})
+
+test('PiAcpAgent: loadSession replays edit toolResult as a structured diff from args', async () => {
+  const originalSpawn = PiRpcProcess.spawn
+  const previousTitles = process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+  ;(PiRpcProcess as any).spawn = async () => {
+    return {
+      onEvent: () => () => {},
+      getMessages: async () => ({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'toolCall',
+                id: 'call_e',
+                name: 'edit',
+                arguments: { path: '/tmp/project/src/a.ts', edits: [{ oldText: 'foo', newText: 'bar' }] }
+              }
+            ]
+          },
+          {
+            role: 'toolResult',
+            toolCallId: 'call_e',
+            toolName: 'edit',
+            content: [{ type: 'text', text: 'Successfully replaced 1 block(s) in a.ts.' }],
+            details: { diff: '-foo\n+bar\n' },
+            isError: false
+          }
+        ]
+      }),
+      getAvailableModels: async () => ({ models: [] }),
+      getState: async () => ({ thinkingLevel: 'medium' })
+    } as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn))
+    ;(agent as any).store = new FakeStore()
+
+    await agent.loadSession({ sessionId: 's1', cwd: '/tmp/project', mcpServers: [] } as any)
+
+    const updates = conn.updates.map(u => (u as any).update)
+    const update = updates.find(u => u?.sessionUpdate === 'tool_call_update' && u?.toolCallId === 'call_e')
+    assert.ok(update)
+    assert.deepEqual(update.content, [{ type: 'diff', path: '/tmp/project/src/a.ts', oldText: 'foo', newText: 'bar' }])
+    assert.equal(update.rawOutput, undefined, 'rawOutput should be suppressed when a structured diff is emitted')
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+    if (previousTitles === undefined) delete process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES
+    else process.env.PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES = previousTitles
+  }
+})
+
+test('PiAcpAgent: loadSession replays write toolResult as a new-file diff from args.content', async () => {
+  const originalSpawn = PiRpcProcess.spawn
+  ;(PiRpcProcess as any).spawn = async () => {
+    return {
+      onEvent: () => () => {},
+      getMessages: async () => ({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'toolCall',
+                id: 'call_w',
+                name: 'write',
+                arguments: { path: '/tmp/project/new.ts', content: 'created\n' }
+              }
+            ]
+          },
+          {
+            role: 'toolResult',
+            toolCallId: 'call_w',
+            toolName: 'write',
+            content: [{ type: 'text', text: 'Successfully wrote 8 bytes to new.ts' }],
+            isError: false
+          }
+        ]
+      }),
+      getAvailableModels: async () => ({ models: [] }),
+      getState: async () => ({ thinkingLevel: 'medium' })
+    } as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const agent = new PiAcpAgent(asAgentConn(conn))
+    ;(agent as any).store = new FakeStore()
+
+    await agent.loadSession({ sessionId: 's1', cwd: '/tmp/project', mcpServers: [] } as any)
+
+    const updates = conn.updates.map(u => (u as any).update)
+    const update = updates.find(u => u?.sessionUpdate === 'tool_call_update' && u?.toolCallId === 'call_w')
+    assert.ok(update)
+    assert.deepEqual(update.content, [
+      { type: 'diff', path: '/tmp/project/new.ts', oldText: null, newText: 'created\n' }
+    ])
+    assert.equal(update.rawOutput, undefined, 'rawOutput should be suppressed when a structured diff is emitted')
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
   }
 })

--- a/test/unit/bash.test.ts
+++ b/test/unit/bash.test.ts
@@ -1,0 +1,49 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { bashMaxOutputLines, truncateToLastLines } from '../../src/acp/translate/bash.js'
+
+beforeEach(() => {
+  delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+})
+
+afterEach(() => {
+  delete process.env.PI_ACP_BASH_MAX_OUTPUT_LINES
+})
+
+test('bashMaxOutputLines: returns undefined by default', () => {
+  assert.equal(bashMaxOutputLines(), undefined)
+})
+
+test('bashMaxOutputLines: parses positive integer', () => {
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '5'
+  assert.equal(bashMaxOutputLines(), 5)
+})
+
+test('bashMaxOutputLines: rejects invalid values', () => {
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '0'
+  assert.equal(bashMaxOutputLines(), undefined)
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = '-1'
+  assert.equal(bashMaxOutputLines(), undefined)
+  process.env.PI_ACP_BASH_MAX_OUTPUT_LINES = 'abc'
+  assert.equal(bashMaxOutputLines(), undefined)
+})
+
+test('truncateToLastLines: returns original text when under limit', () => {
+  assert.equal(truncateToLastLines('1\n2\n3', 5), '1\n2\n3')
+})
+
+test('truncateToLastLines: returns original text when exactly at limit', () => {
+  assert.equal(truncateToLastLines('1\n2\n3', 3), '1\n2\n3')
+})
+
+test('truncateToLastLines: keeps last N lines with truncation marker', () => {
+  assert.equal(truncateToLastLines('1\n2\n3\n4\n5', 2), '... (3 earlier lines truncated)\n4\n5')
+})
+
+test('truncateToLastLines: preserves trailing newline', () => {
+  assert.equal(truncateToLastLines('1\n2\n3\n4\n5\n', 2), '... (3 earlier lines truncated)\n4\n5\n')
+})
+
+test('truncateToLastLines: returns text when maxLines is undefined', () => {
+  assert.equal(truncateToLastLines('1\n2\n3\n4\n5'), '1\n2\n3\n4\n5')
+})


### PR DESCRIPTION
# Description

Coming from opencode, the bash tool calls give visibility around the actual command executed, however when moving to pi, it seems like the `pi-acp` integration doesn't actually show the commands without expanding the tool call in Zed. This changes addresses that by leveraging the `rawInput` field picked up by Zed.

The tool calls for file operations (`read`, `write`, `edit`) were also updated in order to give more visibility around the changes.

# Screenshots

<img width="1582" height="1034" alt="Screenshot 2026-07-03 at 12 34 44" src="https://github.com/user-attachments/assets/26be6ec9-7389-4503-9eee-c83e71da372e" />

<img width="1582" height="1034" alt="Screenshot 2026-07-04 at 00 10 11" src="https://github.com/user-attachments/assets/1f93989c-970c-4e28-9602-72c1137dac12" />


# Notes

An environment variable was added to toggle the feature.

Example for Zed:

```json
"agent_servers": {
  "pi-acp": {
    "type": "custom",
    "command": "node",
    "args": ["/path/to/pi-acp/dist/index.js"],
    "env": {
      "PI_ACP_ENABLE_DESCRIPTIVE_TOOL_TITLES": "true"
    }
  }
}
```

