### PR TITLE
feat(mcp): wire ACP MCP servers through to pi (stdio/http/sse + acp transport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Force capability advertising with:
 
 The merged `.pi/mcp.json` is restored to its original state when the session closes (a `.pi/mcp.json.pi-acp.bak` is kept until restore). If `pi-acp` exits abruptly the managed servers remain in `.pi/mcp.json` and can be removed manually.
 
-Server-originated MCP *notifications* (e.g. `notifications/progress`, `notifications/resources/updated`) are forwarded to pi. Server-originated *requests* (e.g. `sampling/createMessage`) are declined, since handling them would require pi's MCP client to also act as an MCP server.
+Server-originated MCP _notifications_ (e.g. `notifications/progress`, `notifications/resources/updated`) are forwarded to pi. Server-originated _requests_ (e.g. `sampling/createMessage`) are declined, since handling them would require pi's MCP client to also act as an MCP server.
+
+Bridge round-trips over the ACP channel are bounded by timeouts (`mcp/connect` 15s, `mcp/message` 5min to allow long-running tool calls, `mcp/disconnect` 5s), so an unresponsive client cannot leave pi's MCP requests hanging — pi receives a JSON-RPC error instead. A failure while setting up one server (e.g. its socket cannot be created) skips that server without affecting the others. On Windows the shim connects over a named pipe instead of a unix socket.
 
 ## Prerequisites
 
@@ -228,7 +230,7 @@ Project layout:
 ## Limitations
 
 - No ACP filesystem delegation (`fs/*`) and no ACP terminal delegation (`terminal/*`). pi reads/writes and executes locally.
-- ACP-transport MCP servers are bridged to pi over the ACP channel (see [MCP support](#mcp-support)). Server-originated MCP *requests* (e.g. sampling) are not supported.
+- ACP-transport MCP servers are bridged to pi over the ACP channel (see [MCP support](#mcp-support)). Server-originated MCP _requests_ (e.g. sampling) are not supported.
 - Assistant streaming is currently sent as `agent_message_chunk` (no separate thought stream).
 - Queue is implemented client-side and should work like pi's `one-at-a-time`
 - ~~ACP clients don't yet suport session history, but ACP sessions from `pi-acp` can be `/resume`d in pi directly~~

--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ Expect some minor breaking changes.
 - (Zed) `pi-acp` emits “startup info” block into the session (pi version, context, skills, prompts, extensions - similar to `pi` in the terminal). You can disable it by setting `quietStartup: true` in pi settings (`~/.pi/agent/settings.json` or `<project>/.pi/settings.json`). When `quietStartup` is enabled, `pi-acp` will still emit a 'New version available' message if the installed pi version is outdated.
 - (Zed) Session history is supported in Zed starting with [`v0.225.0`](https://zed.dev/releases/preview/0.225.0). Session loading / history maps to pi's session files. Sessions can be resumed both in `pi` and in the ACP client.
 
+## MCP support
+
+`pi-acp` can advertise MCP capabilities to the ACP client and wire ACP-provided MCP servers through to pi when pi has MCP enabled:
+
+- MCP capabilities default to **disabled** for plain pi, because pi has no built-in MCP support.
+- Capabilities are advertised as enabled when `pi-mcp-adapter` is detected globally, or when you set `PI_ACP_ENABLE_MCP=true`.
+- **`http` and `sse`** transports are translated into [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) config entries and merged into the project-local `.pi/mcp.json` for the session.
+- **`stdio`** servers are passed through the same config mechanism.
+- **`acp`** transport ([MCP-over-ACP RFD](https://agentclientprotocol.com/rfds/mcp-over-acp)) is bridged: `pi-acp` spawns a local stdio shim that pi launches via pi-mcp-adapter, and relays messages between that shim and the ACP channel using `mcp/connect`, `mcp/message`, and `mcp/disconnect`.
+
+> **Requires [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) to be installed in pi.** pi has no built-in MCP support; the adapter extension reads `.pi/mcp.json` and spawns/connects the servers. Install it with `pi install npm:pi-mcp-adapter`.
+
+Force capability advertising with:
+
+```json
+{
+  "agent_servers": {
+    "pi": {
+      "type": "custom",
+      "command": "npx",
+      "args": ["-y", "pi-acp"],
+      "env": {
+        "PI_ACP_ENABLE_MCP": "true"
+      }
+    }
+  }
+}
+```
+
+The merged `.pi/mcp.json` is restored to its original state when the session closes (a `.pi/mcp.json.pi-acp.bak` is kept until restore). If `pi-acp` exits abruptly the managed servers remain in `.pi/mcp.json` and can be removed manually.
+
+Server-originated MCP *notifications* (e.g. `notifications/progress`, `notifications/resources/updated`) are forwarded to pi. Server-originated *requests* (e.g. `sampling/createMessage`) are declined, since handling them would require pi's MCP client to also act as an MCP server.
+
 ## Prerequisites
 
 Make sure pi is installed
@@ -195,7 +228,7 @@ Project layout:
 ## Limitations
 
 - No ACP filesystem delegation (`fs/*`) and no ACP terminal delegation (`terminal/*`). pi reads/writes and executes locally.
-- MCP servers are accepted in ACP params and stored in session state, but not wired through to pi in this adapter. If you use [pi MCP adapter](https://github.com/nicobailon/pi-mcp-adapter) it will be available in the ACP client.
+- ACP-transport MCP servers are bridged to pi over the ACP channel (see [MCP support](#mcp-support)). Server-originated MCP *requests* (e.g. sampling) are not supported.
 - Assistant streaming is currently sent as `agent_message_chunk` (no separate thought stream).
 - Queue is implemented client-side and should work like pi's `one-at-a-time`
 - ~~ACP clients don't yet suport session history, but ACP sessions from `pi-acp` can be `/resume`d in pi directly~~

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -24,7 +24,7 @@ import {
   type DeleteSessionResponse
 } from '@agentclientprotocol/sdk'
 import { getAuthMethods } from './auth.js'
-import { SessionManager, type PiAcpSession } from './session.js'
+import { SessionManager, safeSetupMcpServers, type PiAcpSession } from './session.js'
 import { SessionStore } from './session-store.js'
 import { PiRpcProcess } from '../pi-rpc/process.js'
 import { listPiSessions, findPiSession } from './pi-sessions.js'
@@ -42,7 +42,7 @@ import {
 } from './translate/bash.js'
 import { promptToPiMessage } from './translate/prompt.js'
 import { loadSlashCommands, parseCommandArgs, toAvailableCommands } from './slash-commands.js'
-import { getAgentDir, getEnableSkillCommands, getQuietStartup } from './pi-settings.js'
+import { getAgentDir, getEnableSkillCommands, getMcpCapabilities, getQuietStartup } from './pi-settings.js'
 import { toAvailableCommandsFromPiGetCommands } from './pi-commands.js'
 import { maybeAuthRequiredError } from './auth-required.js'
 import { isAbsolute } from 'node:path'
@@ -196,6 +196,9 @@ export class PiAcpAgent implements ACPAgent {
 
       const cwd = opts?.cwd ?? stored.cwd
 
+      // Wire ACP-provided MCP servers through to pi BEFORE spawning pi.
+      const mcpSetup = await safeSetupMcpServers(this.conn, cwd, opts?.mcpServers ?? [])
+
       let proc: PiRpcProcess
       try {
         proc = await PiRpcProcess.spawn({
@@ -204,6 +207,12 @@ export class PiAcpAgent implements ACPAgent {
           piCommand: process.env.PI_ACP_PI_COMMAND
         })
       } catch (e: any) {
+        try {
+          mcpSetup.restore()
+          await mcpSetup.bridge?.dispose()
+        } catch {
+          // ignore
+        }
         if (e?.name === 'PiRpcSpawnError') {
           throw RequestError.internalError({ code: e?.code }, String(e?.message ?? e))
         }
@@ -216,7 +225,8 @@ export class PiAcpAgent implements ACPAgent {
         mcpServers: opts?.mcpServers ?? [],
         conn: this.conn,
         proc,
-        fileCommands
+        fileCommands,
+        mcpSetup
       })
 
       this.lastSessionCwd = cwd
@@ -253,7 +263,10 @@ export class PiAcpAgent implements ACPAgent {
       }),
       agentCapabilities: {
         loadSession: true,
-        mcpCapabilities: { http: false, sse: false },
+        // pi-acp can wire MCP servers through to pi, but plain pi has no MCP.
+        // Only advertise MCP when pi-mcp-adapter is detected or explicitly
+        // enabled with PI_ACP_ENABLE_MCP=true.
+        mcpCapabilities: getMcpCapabilities(),
         promptCapabilities: {
           image: true,
           audio: false,
@@ -279,7 +292,8 @@ export class PiAcpAgent implements ACPAgent {
     const fileCommands = loadSlashCommands(params.cwd)
     const enableSkillCommands = getEnableSkillCommands(params.cwd)
 
-    // Pi doesn't support mcpServers, but we accept and store.
+    // Wire ACP-provided MCP servers through to pi (see McpManager). The setup
+    // happens inside SessionManager.create() before pi is spawned.
     const session = await this.sessions.create({
       cwd: params.cwd,
       mcpServers: params.mcpServers,
@@ -1194,6 +1208,54 @@ export class PiAcpAgent implements ACPAgent {
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
     return { configOptions }
+  }
+
+  /**
+   * Handle ACP extension methods we care about. Currently this routes inbound
+   * MCP-over-ACP messages (server-originated `mcp/message` requests and
+   * notifications) to the session bridge that owns the referenced connectionId.
+   */
+  async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.routeInboundMcp(method, params, true) as Promise<Record<string, unknown>>
+  }
+
+  /** Handle inbound ACP extension notifications (e.g. server-originated MCP notifications). */
+  async extNotification(method: string, params: unknown): Promise<void> {
+    void (await this.routeInboundMcp(method, params, false))
+  }
+
+  private async routeInboundMcp(method: string, params: unknown, isRequest: boolean): Promise<unknown> {
+    if (method === 'mcp/message') {
+      const p = params as { connectionId?: string; method?: string; params?: unknown } | null | undefined
+      const connectionId = typeof p?.connectionId === 'string' ? p.connectionId : null
+      const innerMethod = typeof p?.method === 'string' ? p.method : ''
+      const innerParams = p?.params ?? undefined
+      if (!connectionId) return undefined
+
+      const bridge = this.sessions.findBridgeByConnectionId(connectionId)
+      if (!bridge) {
+        // No matching connection. Decline requests; ignore notifications.
+        if (isRequest) {
+          throw RequestError.invalidParams(`Unknown MCP-over-ACP connectionId: ${connectionId}`)
+        }
+        return undefined
+      }
+
+      const res = bridge.handleInbound(connectionId, innerMethod, innerParams, isRequest)
+      if (!res.handled) {
+        if (isRequest) {
+          throw RequestError.invalidParams(`Unknown MCP-over-ACP connectionId: ${connectionId}`)
+        }
+        return undefined
+      }
+      if (isRequest && res.error) {
+        throw Object.assign(new Error(res.error.message), { code: res.error.code })
+      }
+      return res.result
+    }
+
+    if (isRequest) throw RequestError.methodNotFound(method)
+    return undefined
   }
 }
 

--- a/src/acp/mcp/bridge.ts
+++ b/src/acp/mcp/bridge.ts
@@ -57,6 +57,43 @@ type ActiveConnection = {
   connected: boolean
 }
 
+/**
+ * Timeouts for ACP round-trips. Without these, an unresponsive client would
+ * leave pi's MCP requests pending forever (the shim has no protocol awareness
+ * and cannot fail them itself).
+ */
+export interface AcpMcpBridgeTimeouts {
+  /** `mcp/connect` — session setup, should be fast. */
+  connectMs: number
+  /** `mcp/message` requests — generous: MCP tool calls can be long-running. */
+  messageMs: number
+  /** `mcp/disconnect` — best-effort teardown. */
+  disconnectMs: number
+}
+
+const DEFAULT_TIMEOUTS: AcpMcpBridgeTimeouts = {
+  connectMs: 15_000,
+  messageMs: 300_000,
+  disconnectMs: 5_000
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    timer.unref?.()
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}
+
 /** Path to the built shim script, resolved relative to this module. */
 function resolveShimPath(): string {
   const here = fileURLToPath(import.meta.url)
@@ -77,14 +114,16 @@ function resolveShimPath(): string {
 
 export class AcpMcpBridge {
   private readonly conn: AgentSideConnection
+  private readonly timeouts: AcpMcpBridgeTimeouts
   /** connectionId -> connection state. */
   private readonly connections = new Map<string, ActiveConnection>()
   /** socket server -> server context (acp info + socket path). */
   private readonly servers = new Map<Server, { info: AcpServerInfo; socketPath: string }>()
   private disposed = false
 
-  constructor(conn: AgentSideConnection) {
+  constructor(conn: AgentSideConnection, timeouts: Partial<AcpMcpBridgeTimeouts> = {}) {
     this.conn = conn
+    this.timeouts = { ...DEFAULT_TIMEOUTS, ...timeouts }
   }
 
   /**
@@ -149,7 +188,11 @@ export class AcpMcpBridge {
 
   private async connect(acpId: string, active: ActiveConnection): Promise<void> {
     try {
-      const res = (await this.conn.extMethod('mcp/connect', { acpId })) as { connectionId?: string } | undefined
+      const res = (await withTimeout(
+        this.conn.extMethod('mcp/connect', { acpId }),
+        this.timeouts.connectMs,
+        'mcp/connect'
+      )) as { connectionId?: string } | undefined
       if (res && typeof res.connectionId === 'string' && res.connectionId) {
         // Re-key under the client-assigned connection id.
         this.connections.delete(active.connectionId)
@@ -192,11 +235,15 @@ export class AcpMcpBridge {
     if (isRequest) {
       const id = msg.id
       try {
-        const result = (await this.conn.extMethod('mcp/message', {
-          connectionId: active.connectionId,
-          method: innerMethod,
-          params: innerParams ?? null
-        })) as unknown
+        const result = (await withTimeout(
+          this.conn.extMethod('mcp/message', {
+            connectionId: active.connectionId,
+            method: innerMethod,
+            params: innerParams ?? null
+          }),
+          this.timeouts.messageMs,
+          `mcp/message (${innerMethod})`
+        )) as unknown
         this.writeToShim(active, { jsonrpc: '2.0', id, result: result ?? null })
       } catch (err: any) {
         this.writeToShim(active, {
@@ -295,7 +342,11 @@ export class AcpMcpBridge {
 
   private async disconnect(active: ActiveConnection): Promise<void> {
     try {
-      await this.conn.extMethod('mcp/disconnect', { connectionId: active.connectionId })
+      await withTimeout(
+        this.conn.extMethod('mcp/disconnect', { connectionId: active.connectionId }),
+        this.timeouts.disconnectMs,
+        'mcp/disconnect'
+      )
     } catch {
       // best-effort
     }
@@ -309,17 +360,26 @@ export class AcpMcpBridge {
   private cleanupConnection(active: ActiveConnection): void {
     if (this.disposed) return
     this.connections.delete(active.connectionId)
-    // Notify the client that this connection is gone.
-    void this.conn.extNotification('mcp/disconnect', { connectionId: active.connectionId }).catch(() => {})
+    // Tell the client this connection is gone. Per the SDK schema,
+    // mcp/disconnect is a request (has a response), not a notification.
+    void withTimeout(
+      this.conn.extMethod('mcp/disconnect', { connectionId: active.connectionId }),
+      this.timeouts.disconnectMs,
+      'mcp/disconnect'
+    ).catch(() => {})
   }
 }
 
 function makeSocketPath(acpId: string): string {
   const safe = acpId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 32) || randomUUID()
-  const name = `pi-acp-mcp-${safe}-${randomUUID().slice(0, 8)}.sock`
+  const name = `pi-acp-mcp-${safe}-${randomUUID().slice(0, 8)}`
+  // Windows has no unix domain sockets; net.Server.listen() needs a named pipe.
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\${name}`
+  }
   // Unix domain socket paths have a length limit (~104 chars on macOS). tmpdir
   // keeps us comfortably under that limit.
-  return join(tmpdir(), name)
+  return join(tmpdir(), `${name}.sock`)
 }
 
 function removePath(p: PathLike): Promise<void> {

--- a/src/acp/mcp/bridge.ts
+++ b/src/acp/mcp/bridge.ts
@@ -1,0 +1,342 @@
+/**
+ * MCP-over-ACP transport bridge.
+ *
+ * Implements the `acp` MCP transport from the MCP-over-ACP RFD
+ * (https://agentclientprotocol.com/rfds/mcp-over-acp). ACP-transport MCP
+ * servers are provided by the client and communicate over the ACP channel
+ * itself (no stdio/HTTP). Because pi only speaks stdio MCP (via pi-mcp-adapter),
+ * this bridge presents each ACP-transport server to pi as a local stdio MCP
+ * server (the `mcp-shim` process) and relays messages between that shim and the
+ * client over the ACP channel using `mcp/connect`, `mcp/message`, and
+ * `mcp/disconnect`.
+ *
+ * Message flow (per ACP-transport server):
+ *   - The bridge owns a local socket server (one per server).
+ *   - pi (via pi-mcp-adapter) spawns the shim, which connects to the socket.
+ *   - On socket connect, the bridge sends an ACP `mcp/connect` request (with the
+ *     server's `acpId`) and records the returned `connectionId`.
+ *   - Newline-delimited JSON-RPC lines from the shim are wrapped as
+ *     `mcp/message` requests/notifications and sent to the client.
+ *   - Server-originated *notifications* from the client (`mcp/message` directed
+ *     at this connectionId) are written back to the shim so pi's MCP client
+ *     sees them. Server-originated *requests* (e.g. sampling/createMessage) are
+ *     declined, since they would require pi's MCP client to also act as a server.
+ *   - On teardown (or socket close), the bridge sends `mcp/disconnect`.
+ */
+import type { AgentSideConnection } from '@agentclientprotocol/sdk'
+import { createServer, type Server, type Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+import { PathLike, unlinkSync } from 'node:fs'
+
+/**
+ * A stdio MCP server entry (pi-mcp-adapter format) that pi will spawn.
+ * Returned so the `McpManager` can merge it into `.pi/mcp.json`.
+ */
+export interface StdioShimEntry {
+  command: string
+  args: string[]
+  env: Record<string, string>
+}
+
+type AcpServerInfo = {
+  /** Human-readable name from session/new. */
+  name: string
+  /** Component-provided id from `McpServerAcp.id`. */
+  acpId: string
+}
+
+type ActiveConnection = {
+  /** ACP connection id (client-assigned on mcp/connect, or pre-generated). */
+  connectionId: string
+  socket: Socket
+  /** Lines received from the shim before mcp/connect resolved. */
+  pendingLines: string[]
+  connected: boolean
+}
+
+/** Path to the built shim script, resolved relative to this module. */
+function resolveShimPath(): string {
+  const here = fileURLToPath(import.meta.url)
+  const isWin = process.platform === 'win32'
+  const sep = isWin ? '\\' : '/'
+  const segments = here.split(/[/\\]/)
+  const distIdx = segments.lastIndexOf('dist')
+  if (distIdx >= 0) {
+    return [...segments.slice(0, distIdx), 'dist', 'mcp-shim.js'].join(sep)
+  }
+  // Dev mode (tsx): src/acp/mcp/bridge.ts -> src/mcp-shim.ts
+  const srcIdx = segments.lastIndexOf('src')
+  if (srcIdx >= 0) {
+    return [...segments.slice(0, srcIdx), 'src', 'mcp-shim.ts'].join(sep)
+  }
+  return join(process.cwd(), 'mcp-shim.js')
+}
+
+export class AcpMcpBridge {
+  private readonly conn: AgentSideConnection
+  /** connectionId -> connection state. */
+  private readonly connections = new Map<string, ActiveConnection>()
+  /** socket server -> server context (acp info + socket path). */
+  private readonly servers = new Map<Server, { info: AcpServerInfo; socketPath: string }>()
+  private disposed = false
+
+  constructor(conn: AgentSideConnection) {
+    this.conn = conn
+  }
+
+  /**
+   * Set up bridging for a single ACP-transport MCP server. Returns the stdio
+   * shim entry that should be registered in pi's MCP config so pi launches it.
+   */
+  async addServer(server: AcpServerInfo): Promise<StdioShimEntry> {
+    const socketPath = makeSocketPath(server.acpId)
+
+    const serverSocket = createServer(client => {
+      this.handleShimConnection(client, server)
+    })
+
+    await removePath(socketPath)
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: unknown) => reject(err)
+      serverSocket.once('error', onError)
+      serverSocket.listen(socketPath, () => {
+        serverSocket.off('error', onError)
+        resolve()
+      })
+    })
+
+    this.servers.set(serverSocket, { info: server, socketPath })
+    serverSocket.on('error', () => {
+      // Ignore server-level errors after listen; individual sockets manage themselves.
+    })
+
+    return {
+      command: process.execPath,
+      args: [resolveShimPath()],
+      env: { PI_ACP_MCP_SOCKET: socketPath }
+    }
+  }
+
+  private handleShimConnection(socket: Socket, server: AcpServerInfo): void {
+    let buffer = ''
+    const connectionId = randomUUID()
+    const active: ActiveConnection = {
+      connectionId,
+      socket,
+      pendingLines: [],
+      connected: false
+    }
+    this.connections.set(connectionId, active)
+
+    void this.connect(server.acpId, active)
+
+    socket.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf-8')
+      let nl: number
+      while ((nl = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, nl).replace(/\r$/, '')
+        buffer = buffer.slice(nl + 1)
+        if (line.trim()) this.handleShimLine(active, line)
+      }
+    })
+
+    socket.on('close', () => this.cleanupConnection(active))
+    socket.on('error', () => this.cleanupConnection(active))
+  }
+
+  private async connect(acpId: string, active: ActiveConnection): Promise<void> {
+    try {
+      const res = (await this.conn.extMethod('mcp/connect', { acpId })) as { connectionId?: string } | undefined
+      if (res && typeof res.connectionId === 'string' && res.connectionId) {
+        // Re-key under the client-assigned connection id.
+        this.connections.delete(active.connectionId)
+        active.connectionId = res.connectionId
+        this.connections.set(active.connectionId, active)
+      }
+      active.connected = true
+      const queued = active.pendingLines.splice(0)
+      for (const line of queued) void this.dispatchShimLine(active, line)
+    } catch {
+      // If connect fails, drop the connection; the shim exits and pi sees the
+      // server as unavailable.
+      this.connections.delete(active.connectionId)
+      active.socket.destroy()
+    }
+  }
+
+  private handleShimLine(active: ActiveConnection, line: string): void {
+    if (!active.connected) {
+      active.pendingLines.push(line)
+      return
+    }
+    void this.dispatchShimLine(active, line)
+  }
+
+  private async dispatchShimLine(active: ActiveConnection, line: string): Promise<void> {
+    let msg: any
+    try {
+      msg = JSON.parse(line)
+    } catch {
+      return
+    }
+    if (msg == null || typeof msg !== 'object') return
+    const innerMethod = typeof msg.method === 'string' ? msg.method : undefined
+    if (!innerMethod) return
+
+    const innerParams = msg.params ?? undefined
+    const isRequest = msg.id !== undefined && msg.id !== null
+
+    if (isRequest) {
+      const id = msg.id
+      try {
+        const result = (await this.conn.extMethod('mcp/message', {
+          connectionId: active.connectionId,
+          method: innerMethod,
+          params: innerParams ?? null
+        })) as unknown
+        this.writeToShim(active, { jsonrpc: '2.0', id, result: result ?? null })
+      } catch (err: any) {
+        this.writeToShim(active, {
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: typeof err?.code === 'number' ? err.code : -32603,
+            message: err?.message ?? 'mcp/message failed'
+          }
+        })
+      }
+    } else {
+      try {
+        await this.conn.extNotification('mcp/message', {
+          connectionId: active.connectionId,
+          method: innerMethod,
+          params: innerParams ?? null
+        })
+      } catch {
+        // best-effort
+      }
+    }
+  }
+
+  private writeToShim(active: ActiveConnection, obj: unknown): void {
+    if (active.socket.destroyed) return
+    try {
+      active.socket.write(`${JSON.stringify(obj)}\n`)
+    } catch {
+      // ignore
+    }
+  }
+
+  /** Whether this bridge owns a given ACP connectionId. */
+  hasConnection(connectionId: string): boolean {
+    return this.connections.has(connectionId)
+  }
+
+  /**
+   * Handle an inbound `mcp/message` coming from the client (server-originated).
+   *
+   * Notifications are forwarded to pi by writing them to the shim socket.
+   * Requests are declined with a JSON-RPC error by returning an error result;
+   * pi-acp cannot satisfy server-originated requests (e.g. sampling) because
+   * that would require pi's MCP client to act as an MCP server.
+   *
+   * Returns `true` if a matching connection was found (so the caller knows the
+   * message was handled, even if declined).
+   */
+  handleInbound(
+    connectionId: string,
+    method: string,
+    params: unknown,
+    isRequest: boolean
+  ): { handled: boolean; result?: unknown; error?: { code: number; message: string } } {
+    const active = this.connections.get(connectionId)
+    if (!active) return { handled: false }
+
+    if (!isRequest) {
+      this.writeToShim(active, { jsonrpc: '2.0', method, params: params ?? undefined })
+      return { handled: true }
+    }
+
+    // Decline server-originated requests.
+    return {
+      handled: true,
+      error: {
+        code: -32601,
+        message: `Server-originated MCP request '${method}' is not supported by pi-acp`
+      }
+    }
+  }
+
+  /** Dispose all servers and connections. Sends `mcp/disconnect` best-effort. */
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+
+    const disconnects: Promise<void>[] = []
+    for (const [, active] of this.connections) {
+      disconnects.push(this.disconnect(active))
+    }
+    await Promise.allSettled(disconnects)
+
+    for (const [server, ctx] of this.servers) {
+      try {
+        server.close()
+      } catch {
+        // ignore
+      }
+      removePathSync(ctx.socketPath)
+    }
+    this.servers.clear()
+    this.connections.clear()
+  }
+
+  private async disconnect(active: ActiveConnection): Promise<void> {
+    try {
+      await this.conn.extMethod('mcp/disconnect', { connectionId: active.connectionId })
+    } catch {
+      // best-effort
+    }
+    try {
+      active.socket.destroy()
+    } catch {
+      // ignore
+    }
+  }
+
+  private cleanupConnection(active: ActiveConnection): void {
+    if (this.disposed) return
+    this.connections.delete(active.connectionId)
+    // Notify the client that this connection is gone.
+    void this.conn.extNotification('mcp/disconnect', { connectionId: active.connectionId }).catch(() => {})
+  }
+}
+
+function makeSocketPath(acpId: string): string {
+  const safe = acpId.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 32) || randomUUID()
+  const name = `pi-acp-mcp-${safe}-${randomUUID().slice(0, 8)}.sock`
+  // Unix domain socket paths have a length limit (~104 chars on macOS). tmpdir
+  // keeps us comfortably under that limit.
+  return join(tmpdir(), name)
+}
+
+function removePath(p: PathLike): Promise<void> {
+  return new Promise(resolve => {
+    try {
+      unlinkSync(p)
+    } catch {
+      // ignore
+    }
+    resolve()
+  })
+}
+
+function removePathSync(p: PathLike): void {
+  try {
+    unlinkSync(p)
+  } catch {
+    // ignore
+  }
+}

--- a/src/acp/mcp/config.ts
+++ b/src/acp/mcp/config.ts
@@ -137,13 +137,16 @@ export function writeManagedMcpConfig(
   // during this session) so repeated calls don't overwrite the backup with an
   // already-managed version.
   let backedUp = false
-  try {
-    if (existsSync(path) && !existsSync(backupPath)) {
+  if (existsSync(path) && !existsSync(backupPath)) {
+    try {
       copyFileSync(path, backupPath)
       backedUp = true
+    } catch {
+      // Without a backup we must NOT overwrite the user's file: restore() has
+      // no original to put back and would end up deleting the user's config.
+      // Skip MCP wiring for this session instead.
+      return { path, restore: () => {} }
     }
-  } catch {
-    // Best-effort backup; continue without it.
   }
 
   const merged: PiMcpConfig = {

--- a/src/acp/mcp/config.ts
+++ b/src/acp/mcp/config.ts
@@ -1,0 +1,186 @@
+/**
+ * MCP server config translation and project-local `.pi/mcp.json` management.
+ *
+ * pi has no built-in MCP support. The community `pi-mcp-adapter` extension
+ * reads MCP server configuration from a well-known set of files, including the
+ * project-local `.pi/mcp.json`. To wire ACP-provided stdio/http/sse MCP
+ * servers through to pi, we translate them into pi-mcp-adapter's config format
+ * and merge them into `.pi/mcp.json` for the duration of a session.
+ *
+ * ACP-transport (`type: "acp"`) servers are NOT handled here; they go through
+ * the socket/shim bridge (see `bridge.ts`) and are presented to pi as stdio
+ * servers by the `McpManager`.
+ *
+ * pi-mcp-adapter config format (subset we emit):
+ *   { "mcpServers": { "<name>": { "command": "...", "args": [...], "env": {...} } } }
+ *   { "mcpServers": { "<name>": { "type": "http"|"sse", "url": "...", "headers": {...} } } }
+ */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import type { McpServer } from '@agentclientprotocol/sdk'
+
+/** pi-mcp-adapter config entry. */
+export type PiMcpServerConfig = {
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  type?: 'http' | 'sse' | 'stdio'
+  url?: string
+  headers?: Record<string, string>
+}
+
+export type PiMcpConfig = {
+  mcpServers: Record<string, PiMcpServerConfig>
+}
+
+/** Marker stored alongside managed config so we can identify our own writes. */
+const MANAGED_MARKER_KEY = '_piAcpManaged'
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return Boolean(x) && typeof x === 'object' && !Array.isArray(x)
+}
+
+function envArrayToRecord(env: Array<{ name: string; value: string }> | undefined): Record<string, string> | undefined {
+  if (!Array.isArray(env) || env.length === 0) return undefined
+  const out: Record<string, string> = {}
+  for (const e of env) {
+    if (e && typeof e.name === 'string') out[e.name] = String(e.value ?? '')
+  }
+  return out
+}
+
+function headersArrayToRecord(
+  headers: Array<{ name: string; value: string }> | undefined
+): Record<string, string> | undefined {
+  return envArrayToRecord(headers as Array<{ name: string; value: string }> | undefined)
+}
+
+/**
+ * Translate an ACP MCP server (stdio/http/sse) into a pi-mcp-adapter config entry.
+ * Returns `null` for `acp`-transport servers (handled by the bridge) or for
+ * servers we cannot represent.
+ */
+export function acpMcpServerToPiConfig(server: McpServer): PiMcpServerConfig | null {
+  if ('type' in server) {
+    if (server.type === 'http' || server.type === 'sse') {
+      const cfg: PiMcpServerConfig = { type: server.type, url: server.url }
+      const headers = headersArrayToRecord(server.headers as Array<{ name: string; value: string }> | undefined)
+      if (headers) cfg.headers = headers
+      return cfg
+    }
+
+    if (server.type === 'acp') {
+      // ACP transport is handled by the shim bridge, not the config file.
+      return null
+    }
+    // Fall through: McpServerStdio may omit an explicit `type` field, but if an
+    // explicit unknown type is present we don't know how to handle it.
+    return null
+  }
+
+  // Stdio (default when no `type` field is present).
+  const cfg: PiMcpServerConfig = { command: server.command, args: [...server.args] }
+  const env = envArrayToRecord(server.env as Array<{ name: string; value: string }> | undefined)
+  if (env) cfg.env = env
+  return cfg
+}
+
+function readPiMcpConfig(path: string): PiMcpConfig {
+  try {
+    if (!existsSync(path)) return { mcpServers: {} }
+    const raw = readFileSync(path, 'utf-8')
+    const data = JSON.parse(raw)
+    if (!isObject(data) || !isObject(data.mcpServers)) return { mcpServers: {} }
+    return { mcpServers: data.mcpServers as Record<string, PiMcpServerConfig> }
+  } catch {
+    return { mcpServers: {} }
+  }
+}
+
+function projectMcpConfigPath(cwd: string): string {
+  return resolve(cwd, '.pi', 'mcp.json')
+}
+
+/**
+ * Result of writing a managed MCP config. Call `restore()` when the session
+ * ends to put back the original file contents.
+ */
+export interface ManagedMcpConfig {
+  /** Path of the `.pi/mcp.json` that was (possibly) written. */
+  path: string
+  /** Restore the original file state. Safe to call multiple times. */
+  restore: () => void
+}
+
+/**
+ * Merge `managedServers` into the project-local `.pi/mcp.json`, preserving any
+ * pre-existing user-managed servers (managed entries take precedence on name
+ * collision, since the ACP client explicitly requested them for this session).
+ *
+ * A backup of the original file is kept next to it so `restore()` can recover
+ * even if the process crashed between write and restore.
+ */
+export function writeManagedMcpConfig(
+  cwd: string,
+  managedServers: Record<string, PiMcpServerConfig>
+): ManagedMcpConfig {
+  const path = projectMcpConfigPath(cwd)
+  const backupPath = `${path}.pi-acp.bak`
+
+  if (Object.keys(managedServers).length === 0) {
+    return { path, restore: () => {} }
+  }
+
+  const existing = readPiMcpConfig(path)
+
+  // Preserve a backup of the true user file (only the first time we touch it
+  // during this session) so repeated calls don't overwrite the backup with an
+  // already-managed version.
+  let backedUp = false
+  try {
+    if (existsSync(path) && !existsSync(backupPath)) {
+      copyFileSync(path, backupPath)
+      backedUp = true
+    }
+  } catch {
+    // Best-effort backup; continue without it.
+  }
+
+  const merged: PiMcpConfig = {
+    mcpServers: {
+      ...existing.mcpServers,
+      ...managedServers
+    }
+  }
+
+  ;(merged as Record<string, unknown>)[MANAGED_MARKER_KEY] = true
+
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, 'utf-8')
+  } catch {
+    // If we can't write the config, we simply can't offer these MCP servers to
+    // pi. Don't throw — the rest of the session should still work.
+    return { path, restore: () => {} }
+  }
+
+  let restored = false
+  const restore = () => {
+    if (restored) return
+    restored = true
+    try {
+      if (existsSync(backupPath)) {
+        // Restore the original user file from the backup (covers both the case
+        // where we created it now and where a prior run left one behind).
+        renameSync(backupPath, path)
+      } else if (backedUp === false && existsSync(path)) {
+        // No original existed and we created this file -> remove it.
+        unlinkSync(path)
+      }
+    } catch {
+      // ignore restore failures
+    }
+  }
+
+  return { path, restore }
+}

--- a/src/acp/mcp/index.ts
+++ b/src/acp/mcp/index.ts
@@ -1,0 +1,75 @@
+/**
+ * McpManager: per-session orchestrator that wires ACP-provided MCP servers
+ * through to pi.
+ *
+ * pi has no native MCP support; the community `pi-mcp-adapter` extension reads
+ * MCP server config from `.pi/mcp.json` (among other paths). This manager:
+ *
+ *   - Translates stdio/http/sse ACP servers into pi-mcp-adapter config entries
+ *     and merges them into the project-local `.pi/mcp.json`.
+ *   - For ACP-transport (`type: "acp"`) servers, spins up the shim/socket bridge
+ *     and emits corresponding stdio config entries so pi launches the shim.
+ *
+ * Requires the `pi-mcp-adapter` extension to be installed in pi for pi to
+ * actually connect to these servers. If it is not installed, the config is
+ * still written harmlessly; pi simply won't read it.
+ */
+import type { AgentSideConnection, McpServer } from '@agentclientprotocol/sdk'
+import {
+  acpMcpServerToPiConfig,
+  writeManagedMcpConfig,
+  type ManagedMcpConfig,
+  type PiMcpServerConfig
+} from './config.js'
+import { AcpMcpBridge } from './bridge.js'
+
+export interface McpSetupResult {
+  /** Restore the project `.pi/mcp.json` to its prior state. */
+  restore: () => void
+  /** The bridge (only present when there is at least one ACP-transport server). */
+  bridge: AcpMcpBridge | null
+}
+
+/**
+ * Partition ACP MCP servers by transport and prepare pi-side wiring.
+ *
+ * Returns the managed pi-mcp-adapter config entries to write, plus the bridge
+ * that owns the ACP-transport shim sockets (so the caller can dispose it later
+ * and route inbound ACP messages).
+ */
+export async function setupMcpServers(
+  conn: AgentSideConnection,
+  cwd: string,
+  servers: McpServer[]
+): Promise<McpSetupResult> {
+  const acpServers = servers.filter((s): s is Extract<McpServer, { type: 'acp' }> => 'type' in s && s.type === 'acp')
+
+  let bridge: AcpMcpBridge | null = null
+  const managed: Record<string, PiMcpServerConfig> = {}
+
+  for (const server of servers) {
+    if ('type' in server && server.type === 'acp') {
+      if (!bridge) bridge = new AcpMcpBridge(conn)
+      const shimEntry = await bridge.addServer({ name: server.name, acpId: server.id })
+      // Names must be unique within .pi/mcp.json; if an ACP server collides with
+      // a user-managed server name, the ACP one wins for this session (it's
+      // restored on dispose).
+      managed[server.name] = {
+        command: shimEntry.command,
+        args: shimEntry.args,
+        env: shimEntry.env
+      }
+    } else {
+      const cfg = acpMcpServerToPiConfig(server)
+      if (cfg) managed[server.name] = cfg
+    }
+  }
+
+  void acpServers // (acpServers used implicitly via the loop above)
+  const managedConfig: ManagedMcpConfig = writeManagedMcpConfig(cwd, managed)
+
+  return {
+    restore: managedConfig.restore,
+    bridge
+  }
+}

--- a/src/acp/mcp/index.ts
+++ b/src/acp/mcp/index.ts
@@ -42,22 +42,26 @@ export async function setupMcpServers(
   cwd: string,
   servers: McpServer[]
 ): Promise<McpSetupResult> {
-  const acpServers = servers.filter((s): s is Extract<McpServer, { type: 'acp' }> => 'type' in s && s.type === 'acp')
-
   let bridge: AcpMcpBridge | null = null
   const managed: Record<string, PiMcpServerConfig> = {}
 
   for (const server of servers) {
     if ('type' in server && server.type === 'acp') {
-      if (!bridge) bridge = new AcpMcpBridge(conn)
-      const shimEntry = await bridge.addServer({ name: server.name, acpId: server.id })
-      // Names must be unique within .pi/mcp.json; if an ACP server collides with
-      // a user-managed server name, the ACP one wins for this session (it's
-      // restored on dispose).
-      managed[server.name] = {
-        command: shimEntry.command,
-        args: shimEntry.args,
-        env: shimEntry.env
+      // Isolate per-server failures (e.g. socket listen errors): a broken
+      // ACP-transport server must not take down the wiring for the others.
+      try {
+        if (!bridge) bridge = new AcpMcpBridge(conn)
+        const shimEntry = await bridge.addServer({ name: server.name, acpId: server.id })
+        // Names must be unique within .pi/mcp.json; if an ACP server collides with
+        // a user-managed server name, the ACP one wins for this session (it's
+        // restored on dispose).
+        managed[server.name] = {
+          command: shimEntry.command,
+          args: shimEntry.args,
+          env: shimEntry.env
+        }
+      } catch {
+        // Skip this server; pi simply won't see it.
       }
     } else {
       const cfg = acpMcpServerToPiConfig(server)
@@ -65,7 +69,6 @@ export async function setupMcpServers(
     }
   }
 
-  void acpServers // (acpServers used implicitly via the loop above)
   const managedConfig: ManagedMcpConfig = writeManagedMcpConfig(cwd, managed)
 
   return {

--- a/src/acp/pi-settings.ts
+++ b/src/acp/pi-settings.ts
@@ -40,6 +40,54 @@ export function getAgentDir(): string {
   return process.env.PI_CODING_AGENT_DIR ? resolve(process.env.PI_CODING_AGENT_DIR) : join(homedir(), '.pi', 'agent')
 }
 
+function envFlag(value: string | undefined): boolean | null {
+  if (value == null) return null
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return null
+}
+
+function settingsPackagesIncludeMcpAdapter(settings: Record<string, unknown>): boolean {
+  const packages = settings.packages
+  if (!Array.isArray(packages)) return false
+  return packages.some(pkg => typeof pkg === 'string' && pkg.includes('pi-mcp-adapter'))
+}
+
+/**
+ * Best-effort detection for whether pi can actually consume MCP config.
+ *
+ * pi-acp can bridge ACP MCP servers, but pi itself only uses them when an MCP
+ * extension such as `pi-mcp-adapter` is installed/enabled. `initialize` does not
+ * include a cwd, so project-local detection is not always possible; this checks
+ * global installation/settings and supports an explicit env override.
+ */
+export function getMcpCapabilities(): { http: boolean; sse: boolean; acp: boolean } {
+  const forced = envFlag(process.env.PI_ACP_ENABLE_MCP)
+  const enabled = forced ?? isMcpAdapterDetected()
+  return { http: enabled, sse: enabled, acp: enabled }
+}
+
+export function isMcpAdapterDetected(cwd?: string): boolean {
+  const agentDir = getAgentDir()
+
+  // `pi install npm:pi-mcp-adapter` installs here globally.
+  if (existsSync(join(agentDir, 'npm', 'node_modules', 'pi-mcp-adapter'))) return true
+  if (existsSync(join(agentDir, 'npm', 'node_modules', '.bin', 'pi-mcp-adapter'))) return true
+
+  // If settings still list the package, advertise support even if the package
+  // manager directory has not been inspected/created yet.
+  if (settingsPackagesIncludeMcpAdapter(readJsonFile(join(agentDir, 'settings.json')))) return true
+
+  if (cwd) {
+    const projectRoot = resolve(cwd)
+    if (existsSync(join(projectRoot, '.pi', 'npm', 'node_modules', 'pi-mcp-adapter'))) return true
+    if (settingsPackagesIncludeMcpAdapter(readJsonFile(join(projectRoot, '.pi', 'settings.json')))) return true
+  }
+
+  return false
+}
+
 /**
  * Mirror pi settings semantics (global + project merge, project overrides global).
  * Only returns the bits we currently need.

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -27,6 +27,8 @@ import {
   isBashTool
 } from './translate/bash.js'
 import { toolResultToText } from './translate/pi-tools.js'
+import { setupMcpServers, type McpSetupResult } from './mcp/index.js'
+import type { AcpMcpBridge } from './mcp/bridge.js'
 
 type SessionCreateParams = {
   cwd: string
@@ -147,11 +149,33 @@ function toToolCallLocations(args: unknown, cwd: string, line?: number): ToolCal
   return [{ path: resolvedPath, ...(typeof line === 'number' ? { line } : {}) }]
 }
 
+const NO_MCP_SETUP: McpSetupResult = { restore: () => {}, bridge: null }
+
+/**
+ * Set up MCP wiring for a session. Never throws: if anything goes wrong we fall
+ * back to a no-op setup so the rest of the session is unaffected (pi simply
+ * won't see those MCP servers).
+ */
+async function safeSetupMcpServers(
+  conn: AgentSideConnection,
+  cwd: string,
+  mcpServers: McpServer[]
+): Promise<McpSetupResult> {
+  if (!Array.isArray(mcpServers) || mcpServers.length === 0) return NO_MCP_SETUP
+  try {
+    return await setupMcpServers(conn, cwd, mcpServers)
+  } catch {
+    return NO_MCP_SETUP
+  }
+}
+
+export { safeSetupMcpServers }
+
 export class SessionManager {
   private sessions = new Map<string, PiAcpSession>()
   private readonly store = new SessionStore()
 
-  /** Dispose all sessions and their underlying pi subprocesses. */
+  /** Dispose all sessions, their MCP bridges, and pi subprocesses. */
   disposeAll(): void {
     for (const [id] of this.sessions) this.close(id)
   }
@@ -162,12 +186,18 @@ export class SessionManager {
   }
 
   /**
-   * Dispose a session's underlying pi process and remove it from the manager.
-   * Used when clients explicitly reload a session and we want a fresh pi subprocess.
+   * Dispose a session's underlying pi process, its MCP bridge, and remove it
+   * from the manager. Used when clients explicitly reload a session, or on
+   * teardown.
    */
   close(sessionId: string): void {
     const s = this.sessions.get(sessionId)
     if (!s) return
+    try {
+      s.disposeMcp()
+    } catch {
+      // ignore
+    }
     try {
       s.proc.dispose?.()
     } catch {
@@ -184,7 +214,21 @@ export class SessionManager {
     }
   }
 
+  /** Find the ACP MCP bridge owning a given connectionId, if any. */
+  findBridgeByConnectionId(connectionId: string): AcpMcpBridge | null {
+    for (const [, s] of this.sessions) {
+      const bridge = s.mcpBridge
+      if (bridge?.hasConnection(connectionId)) return bridge
+    }
+    return null
+  }
+
   async create(params: SessionCreateParams): Promise<PiAcpSession> {
+    // Wire ACP-provided MCP servers through to pi BEFORE spawning pi, so pi
+    // picks up the merged `.pi/mcp.json` (and the shim sockets for ACP
+    // transport) at startup.
+    const mcpSetup = await safeSetupMcpServers(params.conn, params.cwd, params.mcpServers)
+
     // Let pi manage session persistence in its default location (~/.pi/agent/sessions/...)
     // so sessions are visible to the regular `pi` CLI.
     let proc: PiRpcProcess
@@ -194,6 +238,13 @@ export class SessionManager {
         piCommand: params.piCommand
       })
     } catch (e) {
+      // Spawn failed; clean up the MCP wiring we just set up.
+      try {
+        mcpSetup.restore()
+        await mcpSetup.bridge?.dispose()
+      } catch {
+        // ignore
+      }
       if (e instanceof PiRpcSpawnError) {
         throw RequestError.internalError({ code: e.code }, e.message)
       }
@@ -220,7 +271,8 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      mcpSetup
     })
 
     this.sessions.set(sessionId, session)
@@ -235,9 +287,13 @@ export class SessionManager {
 
   /**
    * Used by session/load: create a session object bound to an existing sessionId/proc
-   * if it isn't already registered.
+   * if it isn't already registered. `mcpSetup` is prepared by the caller (which
+   * owns the spawn) before spawning pi.
    */
-  getOrCreate(sessionId: string, params: SessionCreateParams & { proc: PiRpcProcess }): PiAcpSession {
+  getOrCreate(
+    sessionId: string,
+    params: SessionCreateParams & { proc: PiRpcProcess; mcpSetup?: McpSetupResult }
+  ): PiAcpSession {
     const existing = this.sessions.get(sessionId)
     if (existing) return existing
 
@@ -247,7 +303,8 @@ export class SessionManager {
       mcpServers: params.mcpServers,
       proc: params.proc,
       conn: params.conn,
-      fileCommands: params.fileCommands ?? []
+      fileCommands: params.fileCommands ?? [],
+      mcpSetup: params.mcpSetup
     })
 
     this.sessions.set(sessionId, session)
@@ -302,6 +359,7 @@ export class PiAcpSession {
     proc: PiRpcProcess
     conn: AgentSideConnection
     fileCommands?: FileSlashCommand[]
+    mcpSetup?: McpSetupResult
   }) {
     this.sessionId = opts.sessionId
     this.cwd = opts.cwd
@@ -309,8 +367,27 @@ export class PiAcpSession {
     this.proc = opts.proc
     this.conn = opts.conn
     this.fileCommands = opts.fileCommands ?? []
+    this.mcpSetup = opts.mcpSetup ?? null
 
     this.proc.onEvent(ev => this.handlePiEvent(ev))
+  }
+
+  private readonly mcpSetup: McpSetupResult | null
+
+  /** The MCP-over-ACP bridge for this session, if any. */
+  get mcpBridge(): AcpMcpBridge | null {
+    return this.mcpSetup?.bridge ?? null
+  }
+
+  /** Tear down MCP wiring (restore `.pi/mcp.json`, dispose shim sockets). */
+  disposeMcp(): void {
+    if (!this.mcpSetup) return
+    try {
+      this.mcpSetup.restore()
+    } catch {
+      // ignore
+    }
+    void this.mcpSetup.bridge?.dispose().catch(() => {})
   }
 
   setStartupInfo(text: string) {

--- a/src/mcp-shim.ts
+++ b/src/mcp-shim.ts
@@ -30,7 +30,7 @@ if (!SOCKET_PATH) {
   process.exit(1)
 }
 
-function pipe(streamA: NodeJS.ReadableStream, streamB: NodeJS.WritableStream): () => void {
+function pipe(streamA: NodeJS.ReadableStream, streamB: NodeJS.WritableStream): void {
   streamA.on('data', (chunk: Buffer | string) => {
     try {
       streamB.write(chunk)
@@ -38,13 +38,8 @@ function pipe(streamA: NodeJS.ReadableStream, streamB: NodeJS.WritableStream): (
       // ignore write errors; teardown will follow on close
     }
   })
-  const onClose = () => teardown()
-  streamA.on('end', onClose)
-  streamA.on('error', () => teardown())
-  return () => {
-    streamA.off('end', onClose)
-    streamA.off('error', onClose)
-  }
+  streamA.on('end', teardown)
+  streamA.on('error', teardown)
 }
 
 let teardownDone = false

--- a/src/mcp-shim.ts
+++ b/src/mcp-shim.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP-over-ACP stdio shim.
+ *
+ * This is a tiny, dependency-free Node script that pi launches as a **stdio
+ * MCP server** (via the pi-mcp-adapter extension). It bridges pi's stdio MCP
+ * transport to a local IPC socket owned by pi-acp, which in turn routes the
+ * messages over the ACP channel using the MCP-over-ACP protocol
+ * (mcp/connect, mcp/message, mcp/disconnect).
+ *
+ * The shim is intentionally dumb: it pipes newline-delimited JSON-RPC bytes
+ * bidirectionally between stdin/stdout (pi side) and the IPC socket (pi-acp
+ * side). All ACP/MCP protocol logic lives in pi-acp.
+ *
+ * Configuration via environment variables:
+ *   PI_ACP_MCP_SOCKET  Path to the unix socket / Windows named pipe to connect to.
+ *
+ * Lifecycle:
+ *   1. pi (via pi-mcp-adapter) spawns this shim.
+ *   2. The shim connects to the socket. pi-acp treats the accepted connection
+ *      as a new MCP-over-ACP connection and sends `mcp/connect` to the client.
+ *   3. Bytes are relayed in both directions.
+ *   4. When either side closes, the shim exits. pi-acp sends `mcp/disconnect`.
+ */
+import { createConnection } from 'node:net'
+
+const SOCKET_PATH = process.env.PI_ACP_MCP_SOCKET
+
+if (!SOCKET_PATH) {
+  process.stderr.write('pi-acp mcp-shim: PI_ACP_MCP_SOCKET is not set\n')
+  process.exit(1)
+}
+
+function pipe(streamA: NodeJS.ReadableStream, streamB: NodeJS.WritableStream): () => void {
+  streamA.on('data', (chunk: Buffer | string) => {
+    try {
+      streamB.write(chunk)
+    } catch {
+      // ignore write errors; teardown will follow on close
+    }
+  })
+  const onClose = () => teardown()
+  streamA.on('end', onClose)
+  streamA.on('error', () => teardown())
+  return () => {
+    streamA.off('end', onClose)
+    streamA.off('error', onClose)
+  }
+}
+
+let teardownDone = false
+function teardown(): void {
+  if (teardownDone) return
+  teardownDone = true
+  try {
+    process.stdin.destroy()
+  } catch {
+    // ignore
+  }
+  process.exit(0)
+}
+
+const socket = createConnection({ path: SOCKET_PATH }, () => {
+  // Flow control: pause stdin until the socket is ready (already true here).
+  process.stdin.resume()
+})
+
+socket.on('error', err => {
+  process.stderr.write(`pi-acp mcp-shim: socket error: ${err?.message ?? err}\n`)
+  teardown()
+})
+
+socket.on('close', teardown)
+
+process.stdin.on('error', teardown)
+
+// stdin (pi MCP client) -> socket (pi-acp)
+pipe(process.stdin, socket)
+// socket (pi-acp) -> stdout (pi MCP client)
+pipe(socket as unknown as NodeJS.ReadableStream, process.stdout)

--- a/test/component/mcp-bridge.test.ts
+++ b/test/component/mcp-bridge.test.ts
@@ -1,27 +1,31 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { AcpMcpBridge } from '../../src/acp/mcp/bridge.js'
-import type { AgentSideConnection } from '@agentclientprotocol/sdk'
+import { setupMcpServers } from '../../src/acp/mcp/index.js'
+import type { AgentSideConnection, McpServer } from '@agentclientprotocol/sdk'
 import { createConnection } from 'node:net'
 import { setTimeout as delay } from 'node:timers/promises'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 /**
  * A fake AgentSideConnection that records outgoing extMethod/extNotification
  * calls and lets the test script the responses.
  */
 class FakeConn {
-  readonly calls: Array<{ method: string; params: any }> = []
+  readonly calls: Array<{ kind: 'method' | 'notification'; method: string; params: any }> = []
   /** Responder for extMethod(method, params) -> result. */
   responder: (method: string, params: any) => any = () => ({ ok: true })
 
   async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
-    this.calls.push({ method, params })
+    this.calls.push({ kind: 'method', method, params })
     const r = this.responder(method, params)
     return r as Record<string, unknown>
   }
 
   async extNotification(method: string, params: Record<string, unknown>): Promise<void> {
-    this.calls.push({ method, params })
+    this.calls.push({ kind: 'notification', method, params })
   }
 }
 
@@ -125,9 +129,7 @@ test('AcpMcpBridge: notifications use extNotification (no response sent)', async
   shim.send({ jsonrpc: '2.0', method: 'notifications/progress', params: { progress: 0.5 } })
   await delay(50)
 
-  const notif = conn.calls.find(
-    c => c.method === 'mcp/message' && c.params?.method === 'notifications/progress'
-  )
+  const notif = conn.calls.find(c => c.method === 'mcp/message' && c.params?.method === 'notifications/progress')
   assert.ok(notif, 'notification forwarded as mcp/message notification')
 
   // Should not have produced a response on the shim.
@@ -140,7 +142,7 @@ test('AcpMcpBridge: notifications use extNotification (no response sent)', async
 
 test('AcpMcpBridge: inbound notification (server-originated) is forwarded to shim', async () => {
   const conn = new FakeConn()
-  conn.responder = (method) => {
+  conn.responder = method => {
     if (method === 'mcp/connect') return { connectionId: 'conn-3' }
     return {}
   }
@@ -159,6 +161,140 @@ test('AcpMcpBridge: inbound notification (server-originated) is forwarded to shi
 
   shim.close()
   await bridge.dispose()
+})
+
+test('AcpMcpBridge: mcp/message rejection produces a JSON-RPC error response', async () => {
+  const conn = new FakeConn()
+  conn.responder = method => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-err' }
+    if (method === 'mcp/message') throw new Error('client exploded')
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-err' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  shim.send({ jsonrpc: '2.0', id: 20, method: 'tools/call', params: { name: 'boom' } })
+  const resp = await shim.nextResponse()
+
+  assert.equal(resp.id, 20)
+  assert.ok(resp.error, 'rejected request surfaces a JSON-RPC error to pi')
+  assert.match(String(resp.error.message), /client exploded/)
+
+  shim.close()
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: unresponsive client times out mcp/message instead of hanging pi', async () => {
+  const conn = new FakeConn()
+  conn.responder = method => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-hang' }
+    if (method === 'mcp/message') return new Promise(() => {}) // never resolves
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection, { messageMs: 100 })
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-hang' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  shim.send({ jsonrpc: '2.0', id: 30, method: 'tools/call', params: { name: 'slow' } })
+  const resp = await shim.nextResponse()
+
+  assert.equal(resp.id, 30)
+  assert.ok(resp.error, 'timed-out request surfaces a JSON-RPC error to pi')
+  assert.match(String(resp.error.message), /timed out/)
+
+  shim.close()
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: unresponsive client times out mcp/connect and drops the shim connection', async () => {
+  const conn = new FakeConn()
+  conn.responder = method => {
+    if (method === 'mcp/connect') return new Promise(() => {}) // never resolves
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection, { connectMs: 100 })
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-cto' })
+
+  const sock = createConnection({ path: entry.env.PI_ACP_MCP_SOCKET })
+  const closed = new Promise<void>(resolve => sock.once('close', resolve))
+  await new Promise<void>((resolve, reject) => {
+    sock.once('connect', resolve)
+    sock.once('error', reject)
+  })
+
+  // The bridge should destroy the socket once mcp/connect times out.
+  const timeout = delay(2000).then(() => {
+    throw new Error('socket was not closed after mcp/connect timeout')
+  })
+  await Promise.race([closed, timeout])
+
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: shim socket close sends mcp/disconnect as a request', async () => {
+  const conn = new FakeConn()
+  conn.responder = method => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-close' }
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-close' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  shim.close()
+  await delay(50)
+
+  const disconnect = conn.calls.find(c => c.method === 'mcp/disconnect')
+  assert.ok(disconnect, 'mcp/disconnect sent when the shim connection drops')
+  assert.equal(disconnect.kind, 'method', 'mcp/disconnect is a request per the SDK schema, not a notification')
+  assert.equal(disconnect.params.connectionId, 'conn-close')
+
+  await bridge.dispose()
+})
+
+test('setupMcpServers: a failing acp server does not take down the other servers', async t => {
+  if (process.platform === 'win32') {
+    t.skip('TMPDIR-based socket failure injection is POSIX-only')
+    return
+  }
+
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-setup-'))
+  const originalTmpdir = process.env.TMPDIR
+  // Point tmpdir at a nonexistent directory so the acp server's socket listen
+  // fails, while everything else keeps working.
+  process.env.TMPDIR = join(cwd, 'does-not-exist')
+
+  try {
+    const servers: McpServer[] = [
+      { type: 'acp', name: 'broken-acp', id: 'broken-id' } as McpServer,
+      { type: 'http', name: 'remote', url: 'https://example.com/mcp', headers: [] } as McpServer
+    ]
+
+    const conn = new FakeConn()
+    const setup = await setupMcpServers(conn as unknown as AgentSideConnection, cwd, servers)
+
+    const configPath = join(cwd, '.pi', 'mcp.json')
+    assert.ok(existsSync(configPath), 'config still written despite the broken acp server')
+    const data = JSON.parse(readFileSync(configPath, 'utf-8'))
+    assert.deepEqual(data.mcpServers.remote, { type: 'http', url: 'https://example.com/mcp' })
+    assert.ok(!('broken-acp' in data.mcpServers), 'broken acp server skipped')
+
+    setup.restore()
+    assert.ok(!existsSync(configPath), 'restore removes the managed config')
+    await setup.bridge?.dispose()
+  } finally {
+    if (originalTmpdir == null) delete process.env.TMPDIR
+    else process.env.TMPDIR = originalTmpdir
+    rmSync(cwd, { recursive: true, force: true })
+  }
 })
 
 test('AcpMcpBridge: hasConnection reflects connect state', async () => {

--- a/test/component/mcp-bridge.test.ts
+++ b/test/component/mcp-bridge.test.ts
@@ -1,0 +1,183 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { AcpMcpBridge } from '../../src/acp/mcp/bridge.js'
+import type { AgentSideConnection } from '@agentclientprotocol/sdk'
+import { createConnection } from 'node:net'
+import { setTimeout as delay } from 'node:timers/promises'
+
+/**
+ * A fake AgentSideConnection that records outgoing extMethod/extNotification
+ * calls and lets the test script the responses.
+ */
+class FakeConn {
+  readonly calls: Array<{ method: string; params: any }> = []
+  /** Responder for extMethod(method, params) -> result. */
+  responder: (method: string, params: any) => any = () => ({ ok: true })
+
+  async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.calls.push({ method, params })
+    const r = this.responder(method, params)
+    return r as Record<string, unknown>
+  }
+
+  async extNotification(method: string, params: Record<string, unknown>): Promise<void> {
+    this.calls.push({ method, params })
+  }
+}
+
+/** Connect a raw socket to the bridge's shim socket and exchange NDJSON. */
+async function connectShim(env: Record<string, string>): Promise<{
+  send: (obj: any) => void
+  nextResponse: () => Promise<any>
+  close: () => void
+}> {
+  const sock = createConnection({ path: env.PI_ACP_MCP_SOCKET })
+  sock.setEncoding('utf-8')
+  let buffer = ''
+  const pending: any[] = []
+  sock.on('data', (chunk: string) => {
+    buffer += chunk
+    let nl: number
+    while ((nl = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, nl).replace(/\r$/, '')
+      buffer = buffer.slice(nl + 1)
+      if (line.trim()) {
+        try {
+          pending.push(JSON.parse(line))
+        } catch {
+          // ignore
+        }
+      }
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    sock.once('connect', resolve)
+    sock.once('error', reject)
+  })
+
+  return {
+    send(obj: any) {
+      sock.write(`${JSON.stringify(obj)}\n`)
+    },
+    async nextResponse() {
+      const deadline = Date.now() + 2000
+      while (pending.length === 0) {
+        if (Date.now() > deadline) throw new Error('timeout waiting for shim response')
+        await delay(10)
+      }
+      return pending.shift()
+    },
+    close() {
+      sock.destroy()
+    }
+  }
+}
+
+test('AcpMcpBridge: connect + tools/call round-trips through mcp/message', async () => {
+  const conn = new FakeConn()
+  let connectionIdSeen: string | null = null
+  conn.responder = (method, params) => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-1' }
+    if (method === 'mcp/message') {
+      connectionIdSeen = params.connectionId
+      if (params.method === 'tools/call') {
+        return { content: [{ type: 'text', text: `called ${params.params?.name}` }] }
+      }
+      return {}
+    }
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-123' })
+
+  const shim = await connectShim(entry.env)
+
+  // Wait for mcp/connect to complete (the bridge fires it on socket connect).
+  await delay(50)
+
+  // Send a tools/call request from the shim (pi side).
+  shim.send({ jsonrpc: '2.0', id: 10, method: 'tools/call', params: { name: 'greet' } })
+  const resp = await shim.nextResponse()
+
+  assert.equal(resp.id, 10)
+  assert.equal(resp.result.content[0].text, 'called greet')
+  assert.equal(connectionIdSeen, 'conn-1')
+
+  shim.close()
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: notifications use extNotification (no response sent)', async () => {
+  const conn = new FakeConn()
+  conn.responder = (method, _params) => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-2' }
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-notif' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  const before = conn.calls.length
+  shim.send({ jsonrpc: '2.0', method: 'notifications/progress', params: { progress: 0.5 } })
+  await delay(50)
+
+  const notif = conn.calls.find(
+    c => c.method === 'mcp/message' && c.params?.method === 'notifications/progress'
+  )
+  assert.ok(notif, 'notification forwarded as mcp/message notification')
+
+  // Should not have produced a response on the shim.
+  // (No id on the notification -> no response line expected.)
+  void before
+
+  shim.close()
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: inbound notification (server-originated) is forwarded to shim', async () => {
+  const conn = new FakeConn()
+  conn.responder = (method) => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-3' }
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-inbound' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  const handled = bridge.handleInbound('conn-3', 'notifications/resources/updated', { uri: 'file:///x' }, false)
+  assert.equal(handled.handled, true)
+
+  const msg = await shim.nextResponse()
+  assert.equal(msg.method, 'notifications/resources/updated')
+  assert.equal(msg.params.uri, 'file:///x')
+
+  shim.close()
+  await bridge.dispose()
+})
+
+test('AcpMcpBridge: hasConnection reflects connect state', async () => {
+  const conn = new FakeConn()
+  conn.responder = (method, _params) => {
+    if (method === 'mcp/connect') return { connectionId: 'conn-4' }
+    return {}
+  }
+
+  const bridge = new AcpMcpBridge(conn as unknown as AgentSideConnection)
+  assert.equal(bridge.hasConnection('conn-4'), false)
+
+  const entry = await bridge.addServer({ name: 'acp-tools', acpId: 'acp-id-has' })
+  const shim = await connectShim(entry.env)
+  await delay(50)
+
+  assert.equal(bridge.hasConnection('conn-4'), true)
+
+  shim.close()
+  await delay(30)
+  await bridge.dispose()
+})

--- a/test/unit/mcp-capabilities.test.ts
+++ b/test/unit/mcp-capabilities.test.ts
@@ -1,0 +1,65 @@
+import test, { afterEach, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR
+const originalEnableMcp = process.env.PI_ACP_ENABLE_MCP
+let dirs: string[] = []
+
+beforeEach(() => {
+  delete process.env.PI_ACP_ENABLE_MCP
+  const dir = mkdtempSync(join(tmpdir(), 'pi-acp-agent-dir-'))
+  dirs.push(dir)
+  process.env.PI_CODING_AGENT_DIR = dir
+})
+
+afterEach(() => {
+  if (originalAgentDir == null) delete process.env.PI_CODING_AGENT_DIR
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir
+
+  if (originalEnableMcp == null) delete process.env.PI_ACP_ENABLE_MCP
+  else process.env.PI_ACP_ENABLE_MCP = originalEnableMcp
+
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true })
+  dirs = []
+})
+
+async function initializeMcpCapabilities() {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  const res = await agent.initialize({ protocolVersion: 1 } as any)
+  assert.ok(res.agentCapabilities)
+  assert.ok(res.agentCapabilities.mcpCapabilities)
+  return res.agentCapabilities.mcpCapabilities
+}
+
+test('MCP capabilities default to false for plain pi (no pi-mcp-adapter detected)', async () => {
+  assert.deepEqual(await initializeMcpCapabilities(), { http: false, sse: false, acp: false })
+})
+
+test('PI_ACP_ENABLE_MCP=true forces MCP capability advertisement on', async () => {
+  process.env.PI_ACP_ENABLE_MCP = 'true'
+  assert.deepEqual(await initializeMcpCapabilities(), { http: true, sse: true, acp: true })
+})
+
+test('PI_ACP_ENABLE_MCP=false forces MCP capability advertisement off', async () => {
+  mkdirSync(join(process.env.PI_CODING_AGENT_DIR!, 'npm', 'node_modules', 'pi-mcp-adapter'), { recursive: true })
+  process.env.PI_ACP_ENABLE_MCP = 'false'
+  assert.deepEqual(await initializeMcpCapabilities(), { http: false, sse: false, acp: false })
+})
+
+test('MCP capabilities turn on when pi-mcp-adapter package dir is detected', async () => {
+  mkdirSync(join(process.env.PI_CODING_AGENT_DIR!, 'npm', 'node_modules', 'pi-mcp-adapter'), { recursive: true })
+  assert.deepEqual(await initializeMcpCapabilities(), { http: true, sse: true, acp: true })
+})
+
+test('MCP capabilities turn on when settings packages include pi-mcp-adapter', async () => {
+  writeFileSync(
+    join(process.env.PI_CODING_AGENT_DIR!, 'settings.json'),
+    JSON.stringify({ packages: ['npm:pi-mcp-adapter'] })
+  )
+  assert.deepEqual(await initializeMcpCapabilities(), { http: true, sse: true, acp: true })
+})

--- a/test/unit/mcp-config.test.ts
+++ b/test/unit/mcp-config.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { acpMcpServerToPiConfig, writeManagedMcpConfig } from '../../src/acp/mcp/config.js'
@@ -103,6 +103,37 @@ test('writeManagedMcpConfig: merges with existing user file and restores it', ()
     assert.ok(restored.mcpServers['user-srv'], 'user server still there after restore')
     assert.ok(!restored.mcpServers['acp-srv'], 'managed server removed after restore')
     assert.ok(!('_piAcpManaged' in restored), 'marker removed after restore')
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('writeManagedMcpConfig: refuses to overwrite user config when the backup cannot be created', t => {
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-mcp-'))
+  try {
+    mkdirSync(join(cwd, '.pi'), { recursive: true })
+    const path = join(cwd, '.pi', 'mcp.json')
+    const original = JSON.stringify({ mcpServers: { 'user-srv': { command: 'u', args: [] } } })
+    writeFileSync(path, original)
+
+    // Dangling symlink at the backup path: existsSync() follows it (false), but
+    // copyFileSync() fails writing through it — simulating a failed backup while
+    // the config file itself is still writable.
+    try {
+      symlinkSync(join(cwd, 'missing-dir', 'target'), `${path}.pi-acp.bak`)
+    } catch {
+      t.skip('symlinks not supported on this platform')
+      return
+    }
+
+    const { restore } = writeManagedMcpConfig(cwd, {
+      'acp-srv': { command: 'node', args: ['a.js'] }
+    })
+
+    assert.equal(readFileSync(path, 'utf-8'), original, 'user config untouched when backup fails')
+    restore()
+    assert.ok(existsSync(path), 'restore must not delete the user config')
+    assert.equal(readFileSync(path, 'utf-8'), original, 'user config intact after restore')
   } finally {
     rmSync(cwd, { recursive: true, force: true })
   }

--- a/test/unit/mcp-config.test.ts
+++ b/test/unit/mcp-config.test.ts
@@ -1,0 +1,121 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { acpMcpServerToPiConfig, writeManagedMcpConfig } from '../../src/acp/mcp/config.js'
+import type { McpServer } from '@agentclientprotocol/sdk'
+
+function stdio(name: string, overrides: Partial<any> = {}): McpServer {
+  return {
+    name,
+    command: 'node',
+    args: ['server.js'],
+    env: [{ name: 'FOO', value: 'bar' }],
+    ...overrides
+  } as McpServer
+}
+
+test('acpMcpServerToPiConfig: stdio server maps command/args/env', () => {
+  const cfg = acpMcpServerToPiConfig(stdio('my-server'))
+  assert.deepEqual(cfg, {
+    command: 'node',
+    args: ['server.js'],
+    env: { FOO: 'bar' }
+  })
+})
+
+test('acpMcpServerToPiConfig: stdio server omits env when absent', () => {
+  const cfg = acpMcpServerToPiConfig({ name: 's', command: 'bin', args: [], env: [] } as unknown as McpServer)
+  assert.deepEqual(cfg, { command: 'bin', args: [] })
+})
+
+test('acpMcpServerToPiConfig: http server maps url + headers', () => {
+  const server: McpServer = {
+    type: 'http',
+    name: 'remote',
+    url: 'https://example.com/mcp',
+    headers: [{ name: 'Authorization', value: 'Bearer x' }]
+  } as McpServer
+  assert.deepEqual(acpMcpServerToPiConfig(server), {
+    type: 'http',
+    url: 'https://example.com/mcp',
+    headers: { Authorization: 'Bearer x' }
+  })
+})
+
+test('acpMcpServerToPiConfig: sse server maps url + headers', () => {
+  const server: McpServer = {
+    type: 'sse',
+    name: 'remote',
+    url: 'https://example.com/sse',
+    headers: []
+  } as McpServer
+  assert.deepEqual(acpMcpServerToPiConfig(server), {
+    type: 'sse',
+    url: 'https://example.com/sse'
+  })
+})
+
+test('acpMcpServerToPiConfig: acp server returns null (handled by bridge)', () => {
+  const server: McpServer = { type: 'acp', name: 'acp-tools', id: 'abc-123' } as McpServer
+  assert.equal(acpMcpServerToPiConfig(server), null)
+})
+
+test('writeManagedMcpConfig: writes a new file when none exists', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-mcp-'))
+  try {
+    const { restore } = writeManagedMcpConfig(cwd, {
+      'my-server': { command: 'node', args: ['s.js'] }
+    })
+    const path = join(cwd, '.pi', 'mcp.json')
+    assert.ok(existsSync(path))
+    const data = JSON.parse(readFileSync(path, 'utf-8'))
+    assert.deepEqual(data.mcpServers['my-server'], { command: 'node', args: ['s.js'] })
+    assert.equal(data._piAcpManaged, true)
+
+    restore()
+    // No original existed -> the managed file is removed.
+    assert.ok(!existsSync(path))
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('writeManagedMcpConfig: merges with existing user file and restores it', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-mcp-'))
+  try {
+    mkdirSync(join(cwd, '.pi'), { recursive: true })
+    const path = join(cwd, '.pi', 'mcp.json')
+    writeFileSync(path, JSON.stringify({ mcpServers: { 'user-srv': { command: 'u', args: [] } } }))
+
+    const { restore } = writeManagedMcpConfig(cwd, {
+      'acp-srv': { command: 'node', args: ['a.js'] }
+    })
+
+    const data = JSON.parse(readFileSync(path, 'utf-8'))
+    assert.ok(data.mcpServers['user-srv'], 'user server preserved')
+    assert.ok(data.mcpServers['acp-srv'], 'managed server added')
+    assert.equal(data._piAcpManaged, true)
+
+    restore()
+    const restored = JSON.parse(readFileSync(path, 'utf-8'))
+    assert.ok(restored.mcpServers['user-srv'], 'user server still there after restore')
+    assert.ok(!restored.mcpServers['acp-srv'], 'managed server removed after restore')
+    assert.ok(!('_piAcpManaged' in restored), 'marker removed after restore')
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('writeManagedMcpConfig: no-op restore when no managed servers', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'pi-acp-mcp-'))
+  try {
+    const { restore } = writeManagedMcpConfig(cwd, {})
+    const path = join(cwd, '.pi', 'mcp.json')
+    assert.ok(!existsSync(path))
+    restore() // should not throw
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/mcp-shim.ts'],
   format: ['esm'],
   platform: 'node',
   target: 'node22',


### PR DESCRIPTION
## Summary

`pi-acp` previously advertised `mcpCapabilities { http: false, sse: false }` and silently dropped every MCP server passed in `session/new` (the only handling was `// Pi doesn't support mcpServers, but we accept and store.`). This PR implements real MCP wiring through to pi **without claiming MCP support for plain pi by default**.

pi has no built-in MCP support, but the community **[pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter)** extension reads `.pi/mcp.json` and spawns/connects MCP servers. This change routes ACP-provided MCP servers through that mechanism when MCP is enabled/detected.

## Capability advertisement

`pi-acp` now advertises MCP capabilities conditionally:

- Default for plain pi / no MCP adapter detected:
  ```json
  { "http": false, "sse": false, "acp": false }
  ```
- If `pi-mcp-adapter` is detected globally (package dir or settings package entry), or `PI_ACP_ENABLE_MCP=true` is set:
  ```json
  { "http": true, "sse": true, "acp": true }
  ```
- `PI_ACP_ENABLE_MCP=false` forces MCP capability advertisement off.

This avoids telling ACP clients that MCP is supported when plain pi cannot actually consume MCP config.

## What it does when MCP is enabled

- **stdio / http / sse** servers are translated into pi-mcp-adapter config entries and merged into the project-local `.pi/mcp.json` for the session. The original file is backed up (`.pi/mcp.json.pi-acp.bak`) and restored on session close.
- **acp transport** ([MCP-over-ACP RFD](https://agentclientprotocol.com/rfds/mcp-over-acp)) is bridged: `pi-acp` spawns a tiny dependency-free stdio shim (`dist/mcp-shim.js`) that pi launches via pi-mcp-adapter. The shim relays newline-delimited JSON-RPC to a local socket owned by `AcpMcpBridge`, which routes messages over the ACP channel using `mcp/connect`, `mcp/message`, and `mcp/disconnect`.
- **Inbound** (server-originated) `mcp/message` notifications are forwarded to the owning session's bridge to the shim to pi. Server-originated *requests* (e.g. `sampling/createMessage`) are declined, since handling them would require pi's MCP client to also act as an MCP server.
- Restores `.pi/mcp.json` and disposes bridges/sockets on session close and on spawn failure.

## Robustness hardening (second commit)

Follow-up commit addressing review feedback and hardening the failure paths:

- **Backup safety** (thanks @ChristianLuciani for catching this): if the backup of the user's `.pi/mcp.json` cannot be created, MCP wiring is skipped for the session instead of overwriting the file — previously `restore()` could delete the user's config in that case.
- **Per-server failure isolation:** a broken `acp`-transport server (e.g. its socket cannot be created) is skipped instead of silently dropping *all* MCP servers for the session.
- **Timeouts on all ACP round-trips:** `mcp/connect` 15s, `mcp/message` 5min (MCP tool calls can legitimately run long), `mcp/disconnect` 5s. An unresponsive client now yields a JSON-RPC error to pi instead of a request that hangs forever.
- **Windows:** the shim socket uses a `\\.\pipe\` named pipe on win32 (unix socket paths don't work with `net.Server.listen` there).
- **Spec correctness:** `mcp/disconnect` on shim socket close is now sent as a request (the SDK schema defines it with a response), matching the dispose path.

## Architecture

```
ACP client --(ACP)--> pi-acp --(RPC)--> pi --(stdio MCP)--> pi-mcp-adapter
                          |                      |
                          |   stdio/http/sse:    |
                          +-> writes .pi/mcp.json<+
                          |
                          |   acp transport:
                          +-> AcpMcpBridge --(socket)--> mcp-shim (pi launches as stdio MCP server)
```

## Requires

The **[pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter)** extension must be installed in pi (`pi install npm:pi-mcp-adapter`). Without it, pi has no MCP support; the capability defaults to false unless explicitly forced with `PI_ACP_ENABLE_MCP=true`.

## Limitations / notes

- `initialize` has no cwd, so project-local-only `pi-mcp-adapter` installs cannot always be detected at capability-advertisement time. Use `PI_ACP_ENABLE_MCP=true` if you rely on a project-local MCP adapter.
- The merged `.pi/mcp.json` is restored on clean session close. If `pi-acp` is killed abruptly, the managed servers remain in `.pi/mcp.json` (a `.pi-acp.bak` is left for manual recovery).
- Server-originated MCP *requests* are declined (see above); notifications are supported.
- The `acp` capability is currently marked **UNSTABLE/experimental** by the ACP schema, matching the RFD status.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run build` all clean.
- Full suite green: **118 tests** (rebased on latest `main`, includes the new upstream tests).
- New unit tests: conditional MCP capability advertisement (default false, env true/false, package-dir detection, settings detection), config translation for stdio/http/sse/acp, `.pi/mcp.json` merge + restore, and a regression test for the backup-failure data-loss case (fails against the pre-fix code).
- New component tests: `AcpMcpBridge` connect round-trip (`mcp/connect` + `mcp/message` request/response), notification forwarding (no spurious response), inbound server-originated notification forwarding to the shim, connection tracking, `mcp/message` rejection surfacing as a JSON-RPC error, message and connect **timeout** behavior, `mcp/disconnect` sent as a request on socket close, and per-server failure isolation in `setupMcpServers` (real socket-failure injection).
- Manual smoke test: built `mcp-shim.js` spawned as a subprocess relays a `tools/call` request through a real socket and returns the response. PASS

## Files

- `src/mcp-shim.ts` — standalone stdio to socket relay shim (built to `dist/mcp-shim.js`).
- `src/acp/mcp/config.ts` — ACP to pi-mcp-adapter config translation + managed `.pi/mcp.json`.
- `src/acp/mcp/bridge.ts` — `AcpMcpBridge`: socket server, `mcp/connect`/`message`/`disconnect` relay.
- `src/acp/mcp/index.ts` — `setupMcpServers` orchestrator.
- `src/acp/pi-settings.ts` — MCP capability detection and env override.
- `src/acp/session.ts` / `src/acp/agent.ts` — lifecycle wiring, conditional capabilities, inbound routing.
- `tsup.config.ts` — build the shim as a second entry.
- README + tests.

Closes the "MCP servers are accepted in ACP params and stored in session state, but not wired through to pi" limitation while keeping default capability advertising honest for plain pi.

