### PR TITLE
feat: add 'max' thinking level

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -51,7 +51,7 @@ import type { AvailableCommand } from '@agentclientprotocol/sdk'
 import { join, dirname, basename } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 type AdvertisedModel = {
   modelId: string
   name: string
@@ -1198,7 +1198,7 @@ export class PiAcpAgent implements ACPAgent {
 }
 
 function isThinkingLevel(x: string): x is ThinkingLevel {
-  return x === 'off' || x === 'minimal' || x === 'low' || x === 'medium' || x === 'high' || x === 'xhigh'
+  return x === 'off' || x === 'minimal' || x === 'low' || x === 'medium' || x === 'high' || x === 'xhigh' || x === 'max'
 }
 
 async function getThinkingState(
@@ -1228,7 +1228,7 @@ async function getThinkingState(
   const tl = typeof state?.thinkingLevel === 'string' ? state.thinkingLevel : null
   if (tl && isThinkingLevel(tl)) current = tl
 
-  const available: ThinkingLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh']
+  const available: ThinkingLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
 
   return {
     currentModeId: current,

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -35,7 +35,7 @@ type PiRpcCommand =
   | { type: 'get_available_models'; id?: string }
   | { type: 'set_model'; id?: string; provider: string; modelId: string }
   // Thinking
-  | { type: 'set_thinking_level'; id?: string; level: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' }
+  | { type: 'set_thinking_level'; id?: string; level: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' }
   // Modes
   | { type: 'set_follow_up_mode'; id?: string; mode: 'all' | 'one-at-a-time' }
   | { type: 'set_steering_mode'; id?: string; mode: 'all' | 'one-at-a-time' }
@@ -258,7 +258,7 @@ export class PiRpcProcess {
     return res.data
   }
 
-  async setThinkingLevel(level: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'): Promise<void> {
+  async setThinkingLevel(level: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'): Promise<void> {
     const res = await this.request({ type: 'set_thinking_level', level })
     if (!res.success) throw new Error(`pi set_thinking_level failed: ${res.error ?? JSON.stringify(res.data)}`)
   }

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -85,7 +85,8 @@ test('PiAcpAgent: newSession returns configOptions for model and thinking select
           { value: 'low', name: 'Thinking: low', description: null },
           { value: 'medium', name: 'Thinking: medium', description: null },
           { value: 'high', name: 'Thinking: high', description: null },
-          { value: 'xhigh', name: 'Thinking: xhigh', description: null }
+          { value: 'xhigh', name: 'Thinking: xhigh', description: null },
+          { value: 'max', name: 'Thinking: max', description: null }
         ]
       }
     ])


### PR DESCRIPTION
Some models now ship a max thinking level as their highest reasoning effort tier (e.g. the DeepSeek V4 series exposes only off, high, and max). Previously, requesting xhigh on these models would silently fall back to high, making the actual maximum unavailable to clients.

This change adds max as a first-class thinking level alongside xhigh, updates the type definitions, the isThinkingLevel guard, the available-options list, and the corresponding test fixtures.

<img width="1532" height="726" alt="image" src="https://github.com/user-attachments/assets/a84a99ee-3fe1-487a-94b3-52f1aaddb236" />


<img width="1190" height="720" alt="image" src="https://github.com/user-attachments/assets/65f8b08c-c95f-4e04-937e-b0a8fcd55cfb" />