### PR TITLE
Bridge Pi session name changes to ACP session updates

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -779,6 +779,17 @@ export class PiAcpSession {
         break
       }
 
+      case 'session_info_changed': {
+        const name = stringProp(ev, 'name')
+        if (name) {
+          this.emit({
+            sessionUpdate: 'session_info_update',
+            title: name
+          })
+        }
+        break
+      }
+
       case 'auto_retry_start': {
         this.emit({
           sessionUpdate: 'agent_message_chunk',

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -268,6 +268,30 @@ test('PiAcpSession: cancels unsupported input and editor extension UI requests w
   assert.match((conn.updates[1]!.update as any).content.text, /editor UI request is not supported/)
 })
 
+test('PiAcpSession: bridges session_info_changed to session_info_update', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'session_info_changed', name: 'My Session' })
+  proc.emit({ type: 'session_info_changed' })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.deepEqual(conn.updates[0]!.update, {
+    sessionUpdate: 'session_info_update',
+    title: 'My Session'
+  })
+})
 test('PiAcpSession: emits agent_message_chunk for auto_retry_start with attempt/maxAttempts and rounded delay', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()


### PR DESCRIPTION
# Forward Pi session name changes to ACP session metadata

Pi emits `session_info_changed` after its session display name changes. `pi-acp` currently ignores that event, so ACP clients such as Zed can retain the initial thread title after Pi assigns a name.

This PR forwards a non-empty event `name` as ACP `session_info_update.title`, the protocol mechanism for updating session metadata.

## Scope

This change forwards Pi session metadata only.

## Tests

- Added component coverage for a named and unnamed `session_info_changed` event.

Reference: [Pi agent session](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/agent-session.ts), which emits `session_info_changed` from `setSessionName`.
