### PR TITLE
🎁 feat(session): emit usage_update notification after turns and model

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -393,6 +393,7 @@ export class PiAcpAgent implements ACPAgent {
     // Important: some clients (e.g. Zed) will ignore notifications for an unknown sessionId.
     // So we must send this *after* the session/new response has been delivered.
     setTimeout(() => {
+      void session.refreshUsage()
       void (async () => {
         try {
           const pi = (await session.proc.getCommands()) as any
@@ -1070,8 +1071,9 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    // Advertise slash commands after the response so the client knows the session exists.
+    // Advertise slash commands and usage after the response so the client knows the session exists.
     setTimeout(() => {
+      void session.refreshUsage()
       void (async () => {
         try {
           const pi = (await proc.getCommands()) as any
@@ -1109,6 +1111,7 @@ export class PiAcpAgent implements ACPAgent {
     const session = await this.restoreSession(params.sessionId)
     await setSessionModel(session.proc, params.modelId)
     await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    void session.refreshUsage()
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1164,6 +1167,7 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    if (configId === MODEL_CONFIG_ID) void session.refreshUsage()
     return { configOptions }
   }
 }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -294,6 +294,7 @@ export class PiAcpSession {
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
   private lastEmit: Promise<void> = Promise.resolve()
+  private usageRefreshId = 0
 
   constructor(opts: {
     sessionId: string
@@ -395,6 +396,33 @@ export class PiAcpSession {
 
   wasCancelRequested(): boolean {
     return this.cancelRequested
+  }
+
+  async refreshUsage(): Promise<void> {
+    const refreshId = ++this.usageRefreshId
+
+    let stats: any
+    try {
+      stats = await this.proc.getSessionStats()
+    } catch {
+      return
+    }
+
+    if (refreshId !== this.usageRefreshId) return
+
+    const used = stats?.contextUsage?.tokens
+    const size = stats?.contextUsage?.contextWindow
+    if (!Number.isFinite(used) || used < 0 || !Number.isFinite(size) || size <= 0) return
+
+    const amount = stats?.cost
+    const cost = Number.isFinite(amount) && amount >= 0 ? { amount, currency: 'USD' } : undefined
+
+    this.emit({
+      sessionUpdate: 'usage_update',
+      used,
+      size,
+      ...(cost ? { cost } : {})
+    })
   }
 
   private emit(update: SessionUpdate): void {
@@ -836,6 +864,7 @@ export class PiAcpSession {
           this.pendingTurn?.resolve(reason)
           this.pendingTurn = null
           this.inAgentLoop = false
+          void this.refreshUsage()
 
           // Start next queued prompt, if any.
           const next = this.turnQueue.shift()

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -819,3 +819,111 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   const reason = await p
   assert.equal(reason, 'end_turn')
 })
+
+test('PiAcpSession: emits current context usage and cumulative cost after a completed turn', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    cost: 0.45,
+    contextUsage: { tokens: 60_000, contextWindow: 200_000, percent: 30 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('report usage')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  assert.deepEqual(
+    conn.updates.find(message => message.update.sessionUpdate === 'usage_update'),
+    {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'usage_update',
+        used: 60_000,
+        size: 200_000,
+        cost: { amount: 0.45, currency: 'USD' }
+      }
+    }
+  )
+})
+
+test('PiAcpSession: does not report unknown usage as zero', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    cost: 0.45,
+    contextUsage: { tokens: null, contextWindow: 200_000, percent: null }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('report usage')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  assert.equal(conn.updates.some(message => message.update.sessionUpdate === 'usage_update'), false)
+})
+
+test('PiAcpSession: discards a stale usage refresh that finishes after a newer one', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const pending: Array<(stats: unknown) => void> = []
+  proc.getSessionStats = async () =>
+    new Promise(resolve => {
+      pending.push(resolve)
+    })
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const olderRefresh = session.refreshUsage()
+  const newerRefresh = session.refreshUsage()
+
+  pending[1]!({ cost: 0.2, contextUsage: { tokens: 2_000, contextWindow: 10_000 } })
+  await newerRefresh
+  pending[0]!({ cost: 0.1, contextUsage: { tokens: 1_000, contextWindow: 10_000 } })
+  await olderRefresh
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  assert.deepEqual(
+    conn.updates.filter(message => message.update.sessionUpdate === 'usage_update'),
+    [
+      {
+        sessionId: 's1',
+        update: {
+          sessionUpdate: 'usage_update',
+          used: 2_000,
+          size: 10_000,
+          cost: { amount: 0.2, currency: 'USD' }
+        }
+      }
+    ]
+  )
+})

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -29,6 +29,7 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   abortCount = 0
+  sessionStats: unknown = {}
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
     this.handlers.push(handler)
@@ -63,6 +64,10 @@ export class FakePiRpcProcess {
 
   async getMessages(): Promise<any> {
     return { messages: [] }
+  }
+
+  async getSessionStats(): Promise<any> {
+    return this.sessionStats
   }
 }
 

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -101,6 +101,7 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
     model: { provider: 'test', id: 'alpha' }
   }
   const setModelCalls: Array<{ provider: string; modelId: string }> = []
+  let usageRefreshCount = 0
 
   const session = {
     sessionId: 's1',
@@ -121,6 +122,9 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
         setModelCalls.push({ provider, modelId })
         state.model = { provider, id: modelId }
       }
+    },
+    async refreshUsage() {
+      usageRefreshCount += 1
     }
   }
 
@@ -134,6 +138,7 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
   } as any)
 
   assert.deepEqual(setModelCalls, [{ provider: 'test', modelId: 'beta' }])
+  assert.equal(usageRefreshCount, 1)
   assert.equal(result.configOptions.find(option => option.id === 'model')?.currentValue, 'test/beta')
   assert.deepEqual(conn.updates, [
     {

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -120,6 +120,7 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
 
   const storeUpserts: any[] = []
   const setModelCalls: Array<{ provider: string; modelId: string }> = []
+  let usageRefreshCount = 0
   const spawnCalls: any[] = []
   const state = {
     thinkingLevel: 'medium',
@@ -129,7 +130,10 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
   const sessions = new FakeSessions((sessionId, params) => ({
     sessionId,
     cwd: params.cwd,
-    proc: params.proc
+    proc: params.proc,
+    async refreshUsage() {
+      usageRefreshCount += 1
+    }
   }))
 
   const originalSpawn = PiRpcProcess.spawn
@@ -177,6 +181,7 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
       }
     ])
     assert.deepEqual(setModelCalls, [{ provider: 'test', modelId: 'beta' }])
+    assert.equal(usageRefreshCount, 1)
     assert.equal(result.configOptions.find(option => option.id === 'model')?.currentValue, 'test/beta')
     assert.deepEqual(storeUpserts, [
       {


### PR DESCRIPTION
# PR: Emit ACP usage updates

## Summary

- Emit ACP `usage_update` notifications with current context usage and cumulative USD cost.
- Refresh usage after session creation or restoration, completed agent turns, and model changes.
- Ignore unavailable or malformed Pi session statistics instead of reporting zero usage.

## Rationale

Pi already exposes `get_session_stats`. Forwarding its context and cost fields lets ACP clients present current usage without parsing agent messages or maintaining a separate estimate.

## Implementation notes

- `PiAcpSession.refreshUsage()` owns Pi statistics normalization and ACP notification emission.
- The refresh counter makes the latest completed request authoritative.
- Existing ACP update serialization is retained.

## Validation

- `npm run typecheck` passed.
- `npm run build` passed.
- The added usage-update tests passed.
- On the upstream baseline, `npm test` completed with 89 passing and 2 pre-existing Windows path-separator assertion failures in `session-events.test.ts` and `session-list-and-load.test.ts`; neither failure exercises usage updates.

## Effect on Zed

<img width="687" height="1325" alt="图片" src="https://github.com/user-attachments/assets/eba2bd87-583d-4b76-b6e0-faf3173661e5" />
