### PR TITLE
fix(acp): wait for Pi session settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @earendil-works/pi-coding-agent
 ```
 
 - Node.js 22+
-- `pi` installed and available on your `PATH` (the adapter runs the `pi` executable)
+- `pi` v0.80.4+ installed and available on your `PATH` (the adapter runs the `pi` executable)
 - Configure `pi` separately for your model providers/API keys
 
 ## Install

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -279,8 +279,9 @@ export class PiAcpSession {
   // and clients may hide progress if we ever downgrade back to `pending`.
   private currentToolCalls = new Map<string, 'pending' | 'in_progress'>()
 
-  // pi can emit multiple `turn_end` events for a single user prompt (e.g. after tool_use).
-  // The overall agent loop completes when `agent_end` is emitted.
+  // pi can emit multiple `turn_end` and `agent_end` events for a single user prompt
+  // when retry, compaction, or queued continuations run. The session-level prompt
+  // completes only when `agent_settled` is emitted.
   private inAgentLoop = false
 
   // For ACP diff support: capture file contents before edit/write mutations,
@@ -483,10 +484,10 @@ export class PiAcpSession {
     })
 
     // Kick off pi, but completion is determined by pi events, not the RPC response.
-    // Important: pi may emit multiple `turn_end` events (e.g. when the model requests tools).
-    // The full prompt is finished when we see `agent_end`.
+    // The prompt RPC only acknowledges acceptance; retry, compaction, or queued
+    // continuations may emit multiple `agent_end` events before `agent_settled`.
     this.proc.prompt(t.message, t.images).catch(err => {
-      // If the subprocess errors before we get an `agent_end`, treat as error unless cancelled.
+      // If the subprocess errors before we get `agent_settled`, treat as error unless cancelled.
       // Also ensure we flush any already-enqueued updates first.
       void this.flushEmits().finally(() => {
         // If this looks like an auth/config issue, surface AUTH_REQUIRED so clients can offer terminal login.
@@ -824,11 +825,18 @@ export class PiAcpSession {
 
       case 'turn_end': {
         // pi uses `turn_end` for sub-steps (e.g. tool_use) and will often start another turn.
-        // Do NOT resolve the ACP `session/prompt` here; wait for `agent_end`.
+        // Do NOT resolve the ACP `session/prompt` here; wait for `agent_settled`.
         break
       }
 
       case 'agent_end': {
+        // One low-level run ended. Pi may still retry, compact, or process a queued
+        // continuation, so keep the ACP turn open until `agent_settled`.
+        this.inAgentLoop = false
+        break
+      }
+
+      case 'agent_settled': {
         // Ensure all updates derived from pi events are delivered before we resolve
         // the ACP `session/prompt` request.
         void this.flushEmits().finally(() => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -636,7 +636,7 @@ test('PiAcpSession: omits edit tool line when oldText matches multiple times', a
   assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: filePath }])
 })
 
-test('PiAcpSession: prompt resolves end_turn on agent_end', async () => {
+test('PiAcpSession: prompt stays open through retry runs until agent_settled', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
@@ -649,10 +649,25 @@ test('PiAcpSession: prompt resolves end_turn on agent_end', async () => {
     fileCommands: []
   })
 
-  const p = session.prompt('hello')
+  let resolved = false
+  const p = session.prompt('hello').then(reason => {
+    resolved = true
+    return reason
+  })
+
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'auto_retry_start', attempt: 1, maxAttempts: 3, delayMs: 2000 })
+  proc.emit({ type: 'agent_end', willRetry: true })
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(resolved, false)
+
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
-  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_end', willRetry: false })
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(resolved, false)
+
+  proc.emit({ type: 'agent_settled' })
   const reason = await p
   assert.equal(reason, 'end_turn')
 })
@@ -692,6 +707,7 @@ test('PiAcpSession: does not re-emit startup info on first prompt after it was a
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
 
   const reason = await p
   assert.equal(reason, 'end_turn')
@@ -715,13 +731,14 @@ test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
   const reason = await p
 
   assert.equal(proc.abortCount, 1)
   assert.equal(reason, 'cancelled')
 })
 
-test('PiAcpSession: queues concurrent prompt and starts it after agent_end', async () => {
+test('PiAcpSession: queues concurrent prompt and starts it after agent_settled', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
@@ -743,6 +760,7 @@ test('PiAcpSession: queues concurrent prompt and starts it after agent_end', asy
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
 
   const r1 = await first
   assert.equal(r1, 'end_turn')
@@ -753,6 +771,7 @@ test('PiAcpSession: queues concurrent prompt and starts it after agent_end', asy
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
 
   const r2 = await second
   assert.equal(r2, 'end_turn')
@@ -780,6 +799,7 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
 
   const r1 = await first
   const r2 = await second
@@ -815,6 +835,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
 
   const reason = await p
   assert.equal(reason, 'end_turn')

--- a/test/component/session-queue-cancel.test.ts
+++ b/test/component/session-queue-cancel.test.ts
@@ -31,10 +31,11 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   assert.equal(await second, 'cancelled')
   assert.equal(await third, 'cancelled')
 
-  // finish first prompt as cancelled (agent_end after abort)
+  // finish first prompt as cancelled after abort
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
   assert.equal(await first, 'cancelled')
 
   // queue should have been cleared, so no further prompt started

--- a/test/component/session-slash-commands.test.ts
+++ b/test/component/session-slash-commands.test.ts
@@ -28,6 +28,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
   const reason = await p
 
   assert.equal(reason, 'end_turn')


### PR DESCRIPTION
## Summary

- keep ACP `session/prompt` open across Pi's low-level `agent_end` events
- complete the ACP turn only when Pi emits session-level `agent_settled`
- add regression coverage for `auto_retry_start → agent_end(willRetry: true) → resumed run → agent_settled`
- update existing queue/cancel/command tests to use the session-level terminal event

## Root cause

Pi now distinguishes two lifecycle boundaries:

- `agent_end`: one low-level run ended and may be followed by retry, compaction, or queued continuation work
- `agent_settled`: no automatic follow-on work remains

ACP requires every `session/update` for a prompt turn to be delivered before the `session/prompt` response. Resolving on the first `agent_end` closes the ACP turn too early when `willRetry: true`; later Pi events are then emitted out of turn.

Observed sequence:

```text
auto_retry_start
agent_end { willRetry: true }
agent_start
...
agent_end { willRetry: false }
agent_settled
```

The new test proves neither `agent_end` resolves the prompt and that `agent_settled` does.

## Relationship to existing work

- Related protocol report: #70
- Overlaps the completion section of #69, which waits for prompt RPC settlement plus `agent_end` to cover post-loop compaction. Pi's current RPC contract identifies `agent_settled` as the direct terminal signal for retry, compaction, and continuations; this PR intentionally stays focused on that lifecycle boundary and does not duplicate #69's compaction-event rendering.

## Compatibility

`agent_settled` was added to Pi in `earendil-works/pi@e9fa5a68` and is available in Pi 0.80.4+. This PR does not add an older-Pi fallback; maintainers may prefer to document or enforce that minimum before merge.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm test` (88/88)
- `npm run build`
- independent defect autoreview: no findings

AI-assisted; implementation and tests were manually inspected and run locally.

