### PR TITLE
fix(acp): tag extension notifications with severity via _meta

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -892,7 +892,8 @@ export class PiAcpSession {
     if (method === 'notify') {
       this.emit({
         sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: stringProp(ev, 'message') ?? 'Pi notification' } satisfies ContentBlock
+        content: { type: 'text', text: stringProp(ev, 'message') ?? 'Pi notification' } satisfies ContentBlock,
+        _meta: { piAcp: { notify: { level: stringProp(ev, 'notifyType') ?? 'info' } } }
       })
       await this.proc.sendExtensionUiResponse({ id, cancelled: true })
       return

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -819,3 +819,63 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   const reason = await p
   assert.equal(reason, 'end_turn')
 })
+
+test('PiAcpSession: tags extension notify chunks with severity in _meta', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'extension_ui_request',
+    id: 'n1',
+    method: 'notify',
+    message: 'MCP: connection failed',
+    notifyType: 'error'
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.deepEqual(conn.updates[0]!.update, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'MCP: connection failed' },
+    _meta: { piAcp: { notify: { level: 'error' } } }
+  })
+  assert.deepEqual(proc.extensionUiResponses[0], { id: 'n1', cancelled: true })
+})
+
+test('PiAcpSession: defaults notify severity to info when notifyType is absent', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'extension_ui_request',
+    id: 'n2',
+    method: 'notify',
+    message: 'heads up'
+  })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.deepEqual((conn.updates[0]!.update as any)._meta, {
+    piAcp: { notify: { level: 'info' } }
+  })
+})


### PR DESCRIPTION
Closes #80.

## Problem

When a pi extension calls `ctx.ui.notify`, pi-acp emits the text as a plain `agent_message_chunk`, which is indistinguishable from model output, and the severity (`info`/`warning`/`error`) is dropped. Clients can't route notifications to a toast/status-bar/log, and the only workaround is fragile text-prefix matching (e.g. `MCP: `).

## Change

Attach pi's `notifyType` to the chunk via the reserved `_meta` field:

```jsonc
{
  "sessionUpdate": "agent_message_chunk",
  "content": { "type": "text", "text": "MCP: connection failed" },
  "_meta": { "piAcp": { "notify": { "level": "error" } } }
}
```

- Backward compatible: unaware clients see no change; aware clients read `_meta.piAcp.notify.level`.
- `level` defaults to `"info"` when pi omits `notifyType`, matching pi's own default.

## Notes

Namespaced under the existing `_meta.piAcp` convention already used elsewhere in `session.ts` (queue depth, bash terminal info), rather than the `pi-acp/notify` key suggested in the issue. Happy to switch in case the slash form is preferred.

## Testing

Added component tests covering the `error` path (full chunk shape + cancelled response) and the `info` default. All 90 tests pass; lint/format clean.