### PR TITLE
fix(acp): recover dead pi child on next prompt instead of silent empty end_turn

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -18,8 +18,7 @@ import {
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
   type SetSessionModeRequest,
-  type SetSessionModeResponse,
-  type StopReason
+  type SetSessionModeResponse
 } from '@agentclientprotocol/sdk'
 import { getAuthMethods } from './auth.js'
 import { SessionManager, type PiAcpSession } from './session.js'
@@ -887,12 +886,14 @@ export class PiAcpAgent implements ACPAgent {
 
     const result = await session.prompt(message, images)
 
-    // ACP StopReason does not include "error"; if pi fails we map to end_turn for now,
-    // unless we know this was a cancellation.
-    const stopReason: StopReason =
-      result === 'error' ? (session.wasCancelRequested() ? 'cancelled' : 'end_turn') : result
+    // ACP StopReason has no "error"; failures must surface as JSON-RPC errors,
+    // not a silent empty end_turn (#82).
+    if (result === 'error') {
+      if (session.wasCancelRequested()) return { stopReason: 'cancelled' }
+      throw RequestError.internalError({}, 'pi prompt failed (the pi process may have exited)')
+    }
 
-    return { stopReason }
+    return { stopReason: result }
   }
 
   async cancel(params: CancelNotification): Promise<void> {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -181,7 +181,13 @@ export class PiAcpAgent implements ACPAgent {
     opts?: { cwd?: string; mcpServers?: LoadSessionRequest['mcpServers'] }
   ): Promise<PiAcpSession> {
     const existing = this.sessions.maybeGet(sessionId)
-    if (existing) return existing
+    // If the pi child died (crash, or an extension called ctx.shutdown()), evict the stale
+    // session so we respawn pi from the recorded session file instead of writing to a dead pipe.
+    if (existing?.proc.isAlive?.() === false) {
+      this.sessions.close(sessionId)
+    } else if (existing) {
+      return existing
+    }
 
     const inFlight = this.restoringSessions.get(sessionId)
     if (inFlight) return inFlight

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -81,6 +81,7 @@ export class PiRpcProcess {
   private readonly pending = new Map<string, { resolve: (v: PiRpcResponse) => void; reject: (e: unknown) => void }>()
   private eventHandlers: Array<(ev: PiRpcEvent) => void> = []
   private readonly preludeLines: string[] = []
+  private exited = false
 
   private constructor(child: ChildProcessWithoutNullStreams) {
     this.child = child
@@ -115,15 +116,21 @@ export class PiRpcProcess {
     })
 
     child.on('exit', (code, signal) => {
+      this.exited = true
       const err = new Error(`pi process exited (code=${code}, signal=${signal})`)
       for (const [, p] of this.pending) p.reject(err)
       this.pending.clear()
     })
 
     child.on('error', err => {
+      this.exited = true
       for (const [, p] of this.pending) p.reject(err)
       this.pending.clear()
     })
+  }
+
+  isAlive(): boolean {
+    return !this.exited
   }
 
   static async spawn(params: SpawnParams): Promise<PiRpcProcess> {

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -8,12 +8,20 @@ import { PiRpcProcess } from '../../src/pi-rpc/process.js'
 import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
 
 class FakeSessions {
-  restoredSession: any = null
+  readonly closed: string[] = []
 
-  constructor(private readonly buildSession: (sessionId: string, params: any) => any) {}
+  constructor(
+    private readonly buildSession: (sessionId: string, params: any) => any,
+    private restoredSession: any = null
+  ) {}
 
   maybeGet(sessionId: string) {
     return this.restoredSession?.sessionId === sessionId ? this.restoredSession : undefined
+  }
+
+  close(sessionId: string) {
+    this.closed.push(sessionId)
+    if (this.restoredSession?.sessionId === sessionId) this.restoredSession = null
   }
 
   getOrCreate(sessionId: string, params: any) {
@@ -91,6 +99,69 @@ test('PiAcpAgent: prompt auto-restores a missing session from SessionStore', asy
         sessionFile: '/tmp/store-project/session.jsonl'
       }
     ])
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+  }
+})
+
+test('PiAcpAgent: prompt evicts a session whose pi child died and respawns from SessionStore', async () => {
+  const conn = new FakeAgentSideConnection()
+  const promptCalls: Array<{ message: string; images: unknown[] }> = []
+  const spawnCalls: any[] = []
+
+  const deadSession = {
+    sessionId: 'stored-session',
+    proc: { isAlive: () => false },
+    prompt() {
+      throw new Error('dead session must not be prompted')
+    }
+  }
+
+  const sessions = new FakeSessions(
+    (sessionId, params) => ({
+      sessionId,
+      cwd: params.cwd,
+      proc: params.proc,
+      async prompt(message: string, images: unknown[]) {
+        promptCalls.push({ message, images })
+        return 'end_turn'
+      }
+    }),
+    deadSession
+  )
+
+  const originalSpawn = PiRpcProcess.spawn
+  ;(PiRpcProcess as any).spawn = async (params: any) => {
+    spawnCalls.push(params)
+    return { onEvent: () => () => {}, isAlive: () => true } as any
+  }
+
+  try {
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = sessions as any
+    ;(agent as any).store = {
+      get(sessionId: string) {
+        if (sessionId !== 'stored-session') return null
+        return { sessionId, cwd: '/tmp/store-project', sessionFile: '/tmp/store-project/session.jsonl' }
+      },
+      upsert() {}
+    }
+
+    const result = await agent.prompt({
+      sessionId: 'stored-session',
+      prompt: [{ type: 'text', text: 'still there?' }]
+    } as any)
+
+    assert.equal(result.stopReason, 'end_turn')
+    assert.deepEqual(sessions.closed, ['stored-session'])
+    assert.deepEqual(spawnCalls, [
+      {
+        cwd: '/tmp/store-project',
+        sessionPath: '/tmp/store-project/session.jsonl',
+        piCommand: process.env.PI_ACP_PI_COMMAND
+      }
+    ])
+    assert.deepEqual(promptCalls, [{ message: 'still there?', images: [] }])
   } finally {
     PiRpcProcess.spawn = originalSpawn
   }

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { RequestError } from '@agentclientprotocol/sdk'
 import { PiAcpAgent } from '../../src/acp/agent.js'
 import { PiRpcProcess } from '../../src/pi-rpc/process.js'
 import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
@@ -162,6 +163,49 @@ test('PiAcpAgent: prompt evicts a session whose pi child died and respawns from 
       }
     ])
     assert.deepEqual(promptCalls, [{ message: 'still there?', images: [] }])
+  } finally {
+    PiRpcProcess.spawn = originalSpawn
+  }
+})
+
+test('PiAcpAgent: prompt surfaces a JSON-RPC error when the pi child dies after the isAlive check', async () => {
+  const conn = new FakeAgentSideConnection()
+  const spawnCalls: any[] = []
+
+  // isAlive() still reports true when restoreSession checks it, but the child is
+  // already gone, so the stdin write rejects with EPIPE.
+  const racyProc = {
+    isAlive: () => true,
+    onEvent: () => () => {},
+    prompt: () => Promise.reject(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+  }
+
+  const originalSpawn = PiRpcProcess.spawn
+  ;(PiRpcProcess as any).spawn = async (params: any) => {
+    spawnCalls.push(params)
+    return { onEvent: () => () => {} } as any
+  }
+
+  try {
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    // Real PiAcpSession (not FakeSessions) so the rejection flows through startTurn.
+    ;(agent as any).sessions.getOrCreate('stored-session', {
+      cwd: '/tmp/store-project',
+      mcpServers: [],
+      conn: asAgentConn(conn),
+      proc: racyProc as any,
+      fileCommands: []
+    })
+
+    await assert.rejects(
+      agent.prompt({
+        sessionId: 'stored-session',
+        prompt: [{ type: 'text', text: 'still there?' }]
+      } as any),
+      (e: any) => e instanceof RequestError && e.code === -32603
+    )
+
+    assert.deepEqual(spawnCalls, [])
   } finally {
     PiRpcProcess.spawn = originalSpawn
   }


### PR DESCRIPTION
Fixes #82

## Problem

If the `pi` child exits between turns (a crash, or an extension calling `ctx.shutdown()`) while pi-acp keeps running, the next `session/prompt` came back as a successful but empty `end_turn`.

The cause was in `restoreSession`: it handed back the registered `PiAcpSession` without checking whether its pi process was still alive.

## Fix

`PiRpcProcess` now tracks whether the child has exited, using the `exit`/`error` handlers it already had, and exposes `isAlive()`. `restoreSession` drops a session whose process reports dead before returning it.

## Testing

Added a unit test for the dead-child case: the stale session gets evicted, pi respawns from the store, and the turn is served.