### PR TITLE
feat(acp): allow disabling update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Point your ACP client to the built `dist/index.js`:
 - `PI_ACP_ENABLE_EMBEDDED_CONTEXT=true` advertises ACP `promptCapabilities.embeddedContext` support to the client.
 - Default: unset/any other value means `false`.
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
+- `PI_ACP_CHECK_FOR_UPDATES=false` skips the startup check for newer pi versions. Unset, `true`, and any other value keep the update check enabled.
 
 You can add the environment variable in the Zed settings with:
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -349,7 +349,7 @@ export class PiAcpAgent implements ACPAgent {
     })
 
     const quietStartup = getQuietStartup(params.cwd)
-    const updateNotice = buildUpdateNotice()
+    const updateNotice = process.env.PI_ACP_CHECK_FOR_UPDATES === 'false' ? null : buildUpdateNotice()
 
     // If quietStartup is enabled, suppress the full "startup info" prelude, but still surface
     // the "New version available" notice (if any) since it's high-signal and actionable.

--- a/test/unit/startup-info-env.test.ts
+++ b/test/unit/startup-info-env.test.ts
@@ -10,16 +10,18 @@ class FakeSessions {
   }
 }
 
-test('PiAcpAgent: quietStartup=true disables startup info generation/emission', async () => {
+test('PiAcpAgent: quietStartup=true and update checks disabled suppress startup info', async () => {
   const prevAgentDir = process.env.PI_CODING_AGENT_DIR
+  const prevCheckForUpdates = process.env.PI_ACP_CHECK_FOR_UPDATES
 
-  // Force quietStartup in pi settings by pointing PI_CODING_AGENT_DIR at a temp dir.
+  // Force quietStartup and disable the update check in a temporary agent environment.
   const { mkdtempSync, writeFileSync } = await import('node:fs')
   const { tmpdir } = await import('node:os')
   const { join } = await import('node:path')
   const dir = mkdtempSync(join(tmpdir(), 'pi-acp-quietstartup-'))
   writeFileSync(join(dir, 'settings.json'), JSON.stringify({ quietStartup: true }, null, 2), 'utf-8')
   process.env.PI_CODING_AGENT_DIR = dir
+  process.env.PI_ACP_CHECK_FOR_UPDATES = 'false'
 
   // Spy on setTimeout calls (agent schedules startup info + available commands)
   const realSetTimeout = globalThis.setTimeout
@@ -62,20 +64,14 @@ test('PiAcpAgent: quietStartup=true disables startup info generation/emission', 
 
     const startupInfo = res?._meta?.piAcp?.startupInfo ?? null
 
-    // When quietStartup=true the full prelude is suppressed. However, an update notice
-    // (if one exists) is still surfaced because it's high-signal and actionable.
-    // The test must tolerate both cases since the live npm check may or may not find an update.
-    if (startupInfo) {
-      assert.match(startupInfo, /New version available/)
-      assert.equal(setStartupInfoCalled, true)
-      assert.equal(timeouts.length, 2)
-    } else {
-      assert.equal(setStartupInfoCalled, false)
-      assert.equal(timeouts.length, 1)
-    }
+    assert.equal(startupInfo, null)
+    assert.equal(setStartupInfoCalled, false)
+    assert.equal(timeouts.length, 1)
   } finally {
     ;(globalThis as any).setTimeout = realSetTimeout
     if (prevAgentDir == null) delete process.env.PI_CODING_AGENT_DIR
     else process.env.PI_CODING_AGENT_DIR = prevAgentDir
+    if (prevCheckForUpdates == null) delete process.env.PI_ACP_CHECK_FOR_UPDATES
+    else process.env.PI_ACP_CHECK_FOR_UPDATES = prevCheckForUpdates
   }
 })


### PR DESCRIPTION
## Summary

Add the `PI_ACP_CHECK_FOR_UPDATES` environment variable to optionally skip Pi update checks during ACP session startup.

Setting the variable to `false` prevents `buildUpdateNotice()` from running. When unset or set to any other value, the existing update-check behavior is preserved.

## Motivation

The update check executes `pi --version` and queries npm synchronously during `session/new`. In sandboxed or latency-sensitive environments, this adds unnecessary startup latency and may depend on network availability.

## Changes

- Skip `buildUpdateNotice()` when `PI_ACP_CHECK_FOR_UPDATES=false`.
- Preserve the existing default behavior.
- Document the environment variable in the README.
- Update the startup test to run without external Pi or npm update checks.

## Testing

Passed:

- `npm run typecheck`
- `npm run lint`
- Targeted startup-info unit test
- `npm run build`

The full test suite reports 86/88 passing on Windows. The two failures are existing path-separator assumptions in:

- `session-events.test.ts`
- `session-list-and-load.test.ts`

The smoke script also has an existing Windows-specific `spawn npm`/`npm.cmd` issue.