### PR TITLE
feat(acp): report context window usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Expect some minor breaking changes.
   - Adds a small set of built-in commands for headless/editor usage
   - Supports skill commands (if enabled in pi settings, they appear as `/skill:skill-name` in the ACP client)
 - Skills are loaded by pi directly and are available in ACP sessions
+- Context-window usage reporting
+  - Sends the current active context occupancy to ACP clients through `usage_update`; Zed uses this update to display context usage
+  - Requires a pi version whose `get_session_stats` response includes `contextUsage`
+  - Immediately after compaction, the client may temporarily retain the previous value until the next model response provides a trustworthy token count
 - (Zed) `pi-acp` emits “startup info” block into the session (pi version, context, skills, prompts, extensions - similar to `pi` in the terminal). You can disable it by setting `quietStartup: true` in pi settings (`~/.pi/agent/settings.json` or `<project>/.pi/settings.json`). When `quietStartup` is enabled, `pi-acp` will still emit a 'New version available' message if the installed pi version is outdated.
 - (Zed) Session history is supported in Zed starting with [`v0.225.0`](https://zed.dev/releases/preview/0.225.0). Session loading / history maps to pi's session files. Sessions can be resumed both in `pi` and in the ACP client.
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -388,6 +388,9 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
+    // The client must learn the session ID before receiving session updates.
+    setTimeout(() => session.refreshContextUsage(), 0)
+
     // Try to send it immediately after session/new returns; if the client ignores it,
     // it will still be emitted as the first chunk of the first prompt.
     if (preludeText) setTimeout(() => session.sendStartupInfoIfPending(), 0)
@@ -1060,6 +1063,8 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
+    await session.refreshContextUsage()
+
     const { configOptions, models, modes } = await getSessionConfiguration(proc)
 
     const response = {
@@ -1138,6 +1143,7 @@ export class PiAcpAgent implements ACPAgent {
     const session = await this.restoreSession(params.sessionId)
     await setSessionModel(session.proc, params.modelId)
     await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    await session.refreshContextUsage()
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1167,6 +1173,7 @@ export class PiAcpAgent implements ACPAgent {
   async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
     const session = await this.restoreSession(params.sessionId)
     const configId = String(params.configId)
+    let refreshContextUsage = false
 
     if (typeof params.value !== 'string') {
       throw RequestError.invalidParams(`Expected string value for config option: ${configId}`)
@@ -1174,6 +1181,7 @@ export class PiAcpAgent implements ACPAgent {
 
     if (configId === MODEL_CONFIG_ID) {
       await setSessionModel(session.proc, params.value)
+      refreshContextUsage = true
     } else if (configId === THOUGHT_LEVEL_CONFIG_ID) {
       if (!isThinkingLevel(params.value)) {
         throw RequestError.invalidParams(`Unknown thinking level: ${params.value}`)
@@ -1193,6 +1201,7 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    if (refreshContextUsage) await session.refreshContextUsage()
     return { configOptions }
   }
 }

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -476,7 +476,7 @@ export class PiAcpAgent implements ACPAgent {
       }
 
       if (cmd === 'session') {
-        const stats = (await session.proc.getSessionStats()) as any
+        const stats = await session.proc.getSessionStats()
 
         const lines: string[] = []
         if (stats?.sessionId) lines.push(`Session: ${stats.sessionId}`)

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -58,6 +58,8 @@ const CONFIRM_PERMISSION_OPTIONS: PermissionOption[] = [
 ]
 const EXTENSION_UI_RAW_INPUT_KEYS = ['title', 'message', 'options', 'placeholder', 'prefill'] as const
 const CHOICE_OPTION_PREFIX = 'choice-'
+const CONTEXT_USAGE_TIMEOUT_MS = 1_000
+const CONTEXT_USAGE_TIMEOUT = Symbol('context-usage-timeout')
 
 export function toContextUsageUpdate(stats: PiSessionStats): SessionUpdate | null {
   const used = stats.contextUsage?.tokens
@@ -439,11 +441,24 @@ export class PiAcpSession {
   }
 
   async refreshContextUsage(): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+
     try {
-      const update = toContextUsageUpdate(await this.proc.getSessionStats())
-      if (update) this.emit(update)
+      const stats = await Promise.race([
+        this.proc.getSessionStats(),
+        new Promise<typeof CONTEXT_USAGE_TIMEOUT>(resolve => {
+          timeout = setTimeout(() => resolve(CONTEXT_USAGE_TIMEOUT), CONTEXT_USAGE_TIMEOUT_MS)
+        })
+      ])
+
+      if (stats !== CONTEXT_USAGE_TIMEOUT) {
+        const update = toContextUsageUpdate(stats)
+        if (update) this.emit(update)
+      }
     } catch {
       // Context usage is auxiliary and must not affect prompt completion.
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout)
     }
 
     await this.flushEmits()

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -67,10 +67,10 @@ export function toContextUsageUpdate(stats: PiSessionStats): SessionUpdate | nul
 
   if (
     typeof used !== 'number' ||
-    !Number.isFinite(used) ||
+    !Number.isSafeInteger(used) ||
     used < 0 ||
     typeof size !== 'number' ||
-    !Number.isFinite(size) ||
+    !Number.isSafeInteger(size) ||
     size <= 0
   ) {
     return null

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -416,6 +416,57 @@ export class PiAcpSession {
     await this.lastEmit
   }
 
+  private async emitContextUsage(): Promise<void> {
+    try {
+      const usage = (await this.proc.getSessionStats()).contextUsage
+      const used = usage?.tokens
+      const size = usage?.contextWindow
+
+      if (
+        typeof used !== 'number' ||
+        !Number.isFinite(used) ||
+        used < 0 ||
+        typeof size !== 'number' ||
+        !Number.isFinite(size) ||
+        size <= 0
+      ) {
+        return
+      }
+
+      this.emit({
+        sessionUpdate: 'usage_update',
+        used,
+        size
+      })
+    } catch {
+      // Context usage is auxiliary and must not affect prompt completion.
+    }
+  }
+
+  private async finishTurn(): Promise<void> {
+    await this.emitContextUsage()
+    await this.flushEmits()
+
+    const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
+    this.pendingTurn?.resolve(reason)
+    this.pendingTurn = null
+    this.inAgentLoop = false
+
+    const next = this.turnQueue.shift()
+    if (next) {
+      this.emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
+      })
+      this.startTurn(next)
+    } else {
+      this.emit({
+        sessionUpdate: 'session_info_update',
+        _meta: { piAcp: { queueDepth: 0, running: false } }
+      })
+    }
+  }
+
   private emitBashToolCall(params: {
     sessionUpdate: 'tool_call' | 'tool_call_update'
     toolCallId: string
@@ -829,29 +880,7 @@ export class PiAcpSession {
       }
 
       case 'agent_end': {
-        // Ensure all updates derived from pi events are delivered before we resolve
-        // the ACP `session/prompt` request.
-        void this.flushEmits().finally(() => {
-          const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
-          this.pendingTurn?.resolve(reason)
-          this.pendingTurn = null
-          this.inAgentLoop = false
-
-          // Start next queued prompt, if any.
-          const next = this.turnQueue.shift()
-          if (next) {
-            this.emit({
-              sessionUpdate: 'agent_message_chunk',
-              content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
-            })
-            this.startTurn(next)
-          } else {
-            this.emit({
-              sessionUpdate: 'session_info_update',
-              _meta: { piAcp: { queueDepth: 0, running: false } }
-            })
-          }
-        })
+        void this.finishTurn()
         break
       }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -11,7 +11,7 @@ import type {
 import { RequestError } from '@agentclientprotocol/sdk'
 import { readFileSync } from 'node:fs'
 import { isAbsolute, resolve as resolvePath } from 'node:path'
-import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent } from '../pi-rpc/process.js'
+import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent, type PiSessionStats } from '../pi-rpc/process.js'
 import { maybeAuthRequiredError } from './auth-required.js'
 import { SessionStore } from './session-store.js'
 import { expandSlashCommand, type FileSlashCommand } from './slash-commands.js'
@@ -58,6 +58,28 @@ const CONFIRM_PERMISSION_OPTIONS: PermissionOption[] = [
 ]
 const EXTENSION_UI_RAW_INPUT_KEYS = ['title', 'message', 'options', 'placeholder', 'prefill'] as const
 const CHOICE_OPTION_PREFIX = 'choice-'
+
+export function toContextUsageUpdate(stats: PiSessionStats): SessionUpdate | null {
+  const used = stats.contextUsage?.tokens
+  const size = stats.contextUsage?.contextWindow
+
+  if (
+    typeof used !== 'number' ||
+    !Number.isFinite(used) ||
+    used < 0 ||
+    typeof size !== 'number' ||
+    !Number.isFinite(size) ||
+    size <= 0
+  ) {
+    return null
+  }
+
+  return {
+    sessionUpdate: 'usage_update',
+    used,
+    size
+  }
+}
 
 function findUniqueLineNumber(text: string, needle: string): number | undefined {
   if (!needle) return undefined
@@ -416,36 +438,19 @@ export class PiAcpSession {
     await this.lastEmit
   }
 
-  private async emitContextUsage(): Promise<void> {
+  async refreshContextUsage(): Promise<void> {
     try {
-      const usage = (await this.proc.getSessionStats()).contextUsage
-      const used = usage?.tokens
-      const size = usage?.contextWindow
-
-      if (
-        typeof used !== 'number' ||
-        !Number.isFinite(used) ||
-        used < 0 ||
-        typeof size !== 'number' ||
-        !Number.isFinite(size) ||
-        size <= 0
-      ) {
-        return
-      }
-
-      this.emit({
-        sessionUpdate: 'usage_update',
-        used,
-        size
-      })
+      const update = toContextUsageUpdate(await this.proc.getSessionStats())
+      if (update) this.emit(update)
     } catch {
       // Context usage is auxiliary and must not affect prompt completion.
     }
+
+    await this.flushEmits()
   }
 
   private async finishTurn(): Promise<void> {
-    await this.emitContextUsage()
-    await this.flushEmits()
+    await this.refreshContextUsage()
 
     const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
     this.pendingTurn?.resolve(reason)

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -68,6 +68,27 @@ type PiExtensionUiResponse =
 
 export type PiRpcEvent = Record<string, unknown>
 
+export interface PiContextUsage {
+  tokens: number | null
+  contextWindow: number
+  percent?: number | null
+}
+
+export interface PiSessionStats {
+  sessionFile?: string
+  sessionId?: string
+  totalMessages?: number
+  tokens?: {
+    input?: number
+    output?: number
+    cacheRead?: number
+    cacheWrite?: number
+    total?: number
+  }
+  cost?: number
+  contextUsage?: PiContextUsage
+}
+
 type SpawnParams = {
   cwd: string
   /** Optional override for `pi` executable name/path */
@@ -284,10 +305,10 @@ export class PiRpcProcess {
     if (!res.success) throw new Error(`pi set_auto_compaction failed: ${res.error ?? JSON.stringify(res.data)}`)
   }
 
-  async getSessionStats(): Promise<unknown> {
+  async getSessionStats(): Promise<PiSessionStats> {
     const res = await this.request({ type: 'get_session_stats' })
     if (!res.success) throw new Error(`pi get_session_stats failed: ${res.error ?? JSON.stringify(res.data)}`)
-    return res.data
+    return res.data as PiSessionStats
   }
 
   async setSessionName(name: string): Promise<void> {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -872,6 +872,41 @@ test('PiAcpSession: stats failures do not change the prompt stop reason', async 
   )
 })
 
+test('PiAcpSession: stats timeout does not block prompt completion', async () => {
+  const realSetTimeout = globalThis.setTimeout
+  ;(globalThis as any).setTimeout = (callback: () => void) => {
+    queueMicrotask(callback)
+    return 0 as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+    proc.getSessionStats = () => new Promise<never>(() => {})
+
+    const session = new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    const prompt = session.prompt('hello')
+    proc.emit({ type: 'agent_start' })
+    proc.emit({ type: 'agent_end' })
+
+    assert.equal(await prompt, 'end_turn')
+    assert.equal(
+      conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+      false
+    )
+  } finally {
+    ;(globalThis as any).setTimeout = realSetTimeout
+  }
+})
+
 test('PiAcpSession: missing stats support is a silent no-op', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -872,6 +872,28 @@ test('PiAcpSession: stats failures do not change the prompt stop reason', async 
   )
 })
 
+test('PiAcpSession: missing stats support is a silent no-op', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  ;(proc as any).getSessionStats = undefined
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  await session.refreshContextUsage()
+
+  assert.equal(
+    conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
 test('PiAcpSession: usage notification failures do not change the prompt stop reason', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -657,6 +657,301 @@ test('PiAcpSession: prompt resolves end_turn on agent_end', async () => {
   assert.equal(reason, 'end_turn')
 })
 
+test('PiAcpSession: emits context usage after agent_end', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: {
+      tokens: 12_345,
+      contextWindow: 200_000
+    }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.deepEqual(
+    conn.updates.find(update => update.update.sessionUpdate === 'usage_update'),
+    {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'usage_update',
+        used: 12_345,
+        size: 200_000
+      }
+    }
+  )
+})
+
+test('PiAcpSession: delivers context usage before resolving the prompt', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: {
+      tokens: 42,
+      contextWindow: 100
+    }
+  }
+
+  const originalSessionUpdate = conn.sessionUpdate.bind(conn)
+  let markUsageDeliveryStarted: () => void
+  const usageDeliveryStarted = new Promise<void>(resolve => {
+    markUsageDeliveryStarted = resolve
+  })
+  let releaseUsageDelivery: (() => void) | undefined
+  const usageDeliveryBlocked = new Promise<void>(resolve => {
+    releaseUsageDelivery = resolve
+  })
+
+  conn.sessionUpdate = async update => {
+    if (update.update.sessionUpdate === 'usage_update') {
+      markUsageDeliveryStarted()
+      await usageDeliveryBlocked
+    }
+    await originalSessionUpdate(update)
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  let promptResolved = false
+  const prompt = session.prompt('hello').then(reason => {
+    promptResolved = true
+    return reason
+  })
+
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  await usageDeliveryStarted
+  assert.equal(promptResolved, false)
+
+  assert.ok(releaseUsageDelivery)
+  releaseUsageDelivery()
+  assert.equal(await prompt, 'end_turn')
+  assert.equal(promptResolved, true)
+})
+
+test('PiAcpSession: skips context usage when stats do not include it', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.equal(
+    conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: skips context usage when tokens are unknown after compaction', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: {
+      tokens: null,
+      contextWindow: 200_000
+    }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.equal(
+    conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: skips invalid context usage values', async t => {
+  const invalidValues = [
+    { name: 'negative tokens', tokens: -1, contextWindow: 100 },
+    { name: 'non-finite tokens', tokens: Number.NaN, contextWindow: 100 },
+    { name: 'zero context window', tokens: 10, contextWindow: 0 },
+    { name: 'negative context window', tokens: 10, contextWindow: -1 },
+    { name: 'non-finite context window', tokens: 10, contextWindow: Number.POSITIVE_INFINITY }
+  ]
+
+  for (const value of invalidValues) {
+    await t.test(value.name, async () => {
+      const conn = new FakeAgentSideConnection()
+      const proc = new FakePiRpcProcess()
+      proc.sessionStats = {
+        contextUsage: {
+          tokens: value.tokens,
+          contextWindow: value.contextWindow
+        }
+      }
+
+      const session = new PiAcpSession({
+        sessionId: 's1',
+        cwd: process.cwd(),
+        mcpServers: [],
+        proc: proc as any,
+        conn: asAgentConn(conn),
+        fileCommands: []
+      })
+
+      const prompt = session.prompt('hello')
+      proc.emit({ type: 'agent_start' })
+      proc.emit({ type: 'agent_end' })
+
+      assert.equal(await prompt, 'end_turn')
+      assert.equal(
+        conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+        false
+      )
+    })
+  }
+})
+
+test('PiAcpSession: stats failures do not change the prompt stop reason', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.getSessionStats = async () => {
+    throw new Error('stats unavailable')
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.equal(
+    conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: usage notification failures do not change the prompt stop reason', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: {
+      tokens: 42,
+      contextWindow: 100
+    }
+  }
+
+  const originalSessionUpdate = conn.sessionUpdate.bind(conn)
+  conn.sessionUpdate = async update => {
+    if (update.update.sessionUpdate === 'usage_update') {
+      throw new Error('client disconnected')
+    }
+    await originalSessionUpdate(update)
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await prompt, 'end_turn')
+})
+
+test('PiAcpSession: queued turns each emit context usage before progressing', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const contextUsages = [
+    { tokens: 100, contextWindow: 1_000 },
+    { tokens: 250, contextWindow: 1_000 }
+  ]
+  proc.getSessionStats = async () => ({
+    contextUsage: contextUsages.shift()!
+  })
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const first = session.prompt('one')
+  const second = session.prompt('two')
+
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await first, 'end_turn')
+  assert.deepEqual(
+    conn.updates.filter(update => update.update.sessionUpdate === 'usage_update').map(update => update.update),
+    [{ sessionUpdate: 'usage_update', used: 100, size: 1_000 }]
+  )
+  assert.equal(proc.prompts.length, 2)
+
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+
+  assert.equal(await second, 'end_turn')
+  assert.deepEqual(
+    conn.updates.filter(update => update.update.sessionUpdate === 'usage_update').map(update => update.update),
+    [
+      { sessionUpdate: 'usage_update', used: 100, size: 1_000 },
+      { sessionUpdate: 'usage_update', used: 250, size: 1_000 }
+    ]
+  )
+})
+
 test('PiAcpSession: does not re-emit startup info on first prompt after it was already sent', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
@@ -700,6 +995,12 @@ test('PiAcpSession: does not re-emit startup info on first prompt after it was a
 test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: {
+      tokens: 42,
+      contextWindow: 100
+    }
+  }
 
   const session = new PiAcpSession({
     sessionId: 's1',
@@ -719,6 +1020,11 @@ test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
 
   assert.equal(proc.abortCount, 1)
   assert.equal(reason, 'cancelled')
+  assert.deepEqual(conn.updates.find(update => update.update.sessionUpdate === 'usage_update')?.update, {
+    sessionUpdate: 'usage_update',
+    used: 42,
+    size: 100
+  })
 })
 
 test('PiAcpSession: queues concurrent prompt and starts it after agent_end', async () => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -806,9 +806,13 @@ test('PiAcpSession: skips context usage when tokens are unknown after compaction
 test('PiAcpSession: skips invalid context usage values', async t => {
   const invalidValues = [
     { name: 'negative tokens', tokens: -1, contextWindow: 100 },
+    { name: 'fractional tokens', tokens: 1.5, contextWindow: 100 },
+    { name: 'unsafe integer tokens', tokens: Number.MAX_SAFE_INTEGER + 1, contextWindow: 100 },
     { name: 'non-finite tokens', tokens: Number.NaN, contextWindow: 100 },
     { name: 'zero context window', tokens: 10, contextWindow: 0 },
     { name: 'negative context window', tokens: 10, contextWindow: -1 },
+    { name: 'fractional context window', tokens: 10, contextWindow: 100.5 },
+    { name: 'unsafe integer context window', tokens: 10, contextWindow: Number.MAX_SAFE_INTEGER + 1 },
     { name: 'non-finite context window', tokens: 10, contextWindow: Number.POSITIVE_INFINITY }
   ]
 

--- a/test/component/session-list-and-load.test.ts
+++ b/test/component/session-list-and-load.test.ts
@@ -88,6 +88,12 @@ test('PiAcpAgent: listSessions lists pi sessions and loadSession replays history
             { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] }
           ]
         }),
+        getSessionStats: async () => ({
+          contextUsage: {
+            tokens: 12_345,
+            contextWindow: 200_000
+          }
+        }),
         getAvailableModels: async () => ({ models: [] }),
         getState: async () => ({ thinkingLevel: 'medium' })
       } as any
@@ -104,6 +110,25 @@ test('PiAcpAgent: listSessions lists pi sessions and loadSession replays history
 
       assert.ok(texts.some(t => t.kind === 'user_message_chunk' && t.text === 'Hello'))
       assert.ok(texts.some(t => t.kind === 'agent_message_chunk' && t.text === 'Hi there!'))
+
+      const historyEnd = conn.updates
+        .map(
+          update =>
+            update.update.sessionUpdate === 'agent_message_chunk' &&
+            (update.update as any).content?.text === 'Hi there!'
+        )
+        .lastIndexOf(true)
+      const usageIndex = conn.updates.findIndex(update => update.update.sessionUpdate === 'usage_update')
+
+      assert.ok(usageIndex > historyEnd)
+      assert.deepEqual(conn.updates[usageIndex], {
+        sessionId: 'sess-1',
+        update: {
+          sessionUpdate: 'usage_update',
+          used: 12_345,
+          size: 200_000
+        }
+      })
     } finally {
       PiRpcProcess.spawn = originalSpawn
     }

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -1,5 +1,5 @@
 import type { AgentSideConnection } from '@agentclientprotocol/sdk'
-import type { PiRpcEvent } from '../../src/pi-rpc/process.js'
+import type { PiRpcEvent, PiSessionStats } from '../../src/pi-rpc/process.js'
 
 type SessionUpdateMsg = Parameters<AgentSideConnection['sessionUpdate']>[0]
 
@@ -28,6 +28,7 @@ export class FakePiRpcProcess {
   // spies
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
+  sessionStats: PiSessionStats = {}
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -63,6 +64,10 @@ export class FakePiRpcProcess {
 
   async getMessages(): Promise<any> {
     return { messages: [] }
+  }
+
+  async getSessionStats(): Promise<PiSessionStats> {
+    return this.sessionStats
   }
 }
 

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -1,7 +1,8 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { PiAcpAgent } from '../../src/acp/agent.js'
-import { FakeAgentSideConnection, asAgentConn } from '../helpers/fakes.js'
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
 
 class FakeSessions {
   constructor(private readonly session: any) {}
@@ -94,6 +95,62 @@ test('PiAcpAgent: newSession returns configOptions for model and thinking select
   }
 })
 
+test('PiAcpAgent: newSession emits initial context usage only after returning the session', async () => {
+  const realSetTimeout = globalThis.setTimeout
+  const scheduled: Array<() => unknown> = []
+  ;(globalThis as any).setTimeout = (callback: () => unknown) => {
+    scheduled.push(callback)
+    return 0 as any
+  }
+
+  try {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+    proc.sessionStats = {
+      contextUsage: {
+        tokens: 1_234,
+        contextWindow: 100_000
+      }
+    }
+
+    const session = new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+    ;(agent as any).sessions = new FakeSessions(session) as any
+
+    const result = await agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any)
+
+    assert.equal(result.sessionId, 's1')
+    assert.equal(
+      conn.updates.some(update => update.update.sessionUpdate === 'usage_update'),
+      false
+    )
+
+    for (const callback of scheduled) await callback()
+
+    assert.deepEqual(
+      conn.updates.find(update => update.update.sessionUpdate === 'usage_update'),
+      {
+        sessionId: 's1',
+        update: {
+          sessionUpdate: 'usage_update',
+          used: 1_234,
+          size: 100_000
+        }
+      }
+    )
+  } finally {
+    ;(globalThis as any).setTimeout = realSetTimeout
+  }
+})
+
 test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits config_option_update', async () => {
   const conn = new FakeAgentSideConnection()
   const state = {
@@ -120,7 +177,26 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
       async setModel(provider: string, modelId: string) {
         setModelCalls.push({ provider, modelId })
         state.model = { provider, id: modelId }
+      },
+      async getSessionStats() {
+        return {
+          contextUsage: {
+            tokens: 500,
+            contextWindow: state.model.id === 'beta' ? 200_000 : 100_000
+          }
+        }
       }
+    },
+    async refreshContextUsage() {
+      const stats = await this.proc.getSessionStats()
+      await conn.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: 'usage_update',
+          used: stats.contextUsage.tokens,
+          size: stats.contextUsage.contextWindow
+        }
+      })
     }
   }
 
@@ -142,8 +218,79 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
         sessionUpdate: 'config_option_update',
         configOptions: result.configOptions
       }
+    },
+    {
+      sessionId: 's1',
+      update: {
+        sessionUpdate: 'usage_update',
+        used: 500,
+        size: 200_000
+      }
     }
   ])
+})
+
+test('PiAcpAgent: unstable_setSessionModel refreshes context usage for the selected model', async () => {
+  const conn = new FakeAgentSideConnection()
+  const state = {
+    thinkingLevel: 'medium',
+    model: { provider: 'test', id: 'alpha' }
+  }
+  const setModelCalls: Array<{ provider: string; modelId: string }> = []
+
+  const session = {
+    sessionId: 's1',
+    cwd: process.cwd(),
+    proc: {
+      async getAvailableModels() {
+        return {
+          models: [
+            { provider: 'test', id: 'alpha', name: 'Alpha' },
+            { provider: 'test', id: 'beta', name: 'Beta' }
+          ]
+        }
+      },
+      async getState() {
+        return state
+      },
+      async setModel(provider: string, modelId: string) {
+        setModelCalls.push({ provider, modelId })
+        state.model = { provider, id: modelId }
+      }
+    },
+    async refreshContextUsage() {
+      await conn.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: 'usage_update',
+          used: 500,
+          size: state.model.id === 'beta' ? 200_000 : 100_000
+        }
+      })
+    }
+  }
+
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  await agent.unstable_setSessionModel({
+    sessionId: 's1',
+    modelId: 'test/beta'
+  })
+
+  assert.deepEqual(setModelCalls, [{ provider: 'test', modelId: 'beta' }])
+  assert.deepEqual(
+    conn.updates.map(update => update.update.sessionUpdate),
+    ['config_option_update', 'usage_update']
+  )
+  assert.deepEqual(conn.updates.at(-1), {
+    sessionId: 's1',
+    update: {
+      sessionUpdate: 'usage_update',
+      used: 500,
+      size: 200_000
+    }
+  })
 })
 
 test('PiAcpAgent: setSessionConfigOption maps thought level changes to pi and emits sync updates', async () => {

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -129,7 +129,8 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
   const sessions = new FakeSessions((sessionId, params) => ({
     sessionId,
     cwd: params.cwd,
-    proc: params.proc
+    proc: params.proc,
+    async refreshContextUsage() {}
   }))
 
   const originalSpawn = PiRpcProcess.spawn

--- a/test/unit/startup-info-env.test.ts
+++ b/test/unit/startup-info-env.test.ts
@@ -68,10 +68,10 @@ test('PiAcpAgent: quietStartup=true disables startup info generation/emission', 
     if (startupInfo) {
       assert.match(startupInfo, /New version available/)
       assert.equal(setStartupInfoCalled, true)
-      assert.equal(timeouts.length, 2)
+      assert.equal(timeouts.length, 3)
     } else {
       assert.equal(setStartupInfoCalled, false)
-      assert.equal(timeouts.length, 1)
+      assert.equal(timeouts.length, 2)
     }
   } finally {
     ;(globalThis as any).setTimeout = realSetTimeout


### PR DESCRIPTION
## Summary

This PR enables ACP clients to display the current context-window occupancy of a Pi session through the standard `usage_update` session update.

The adapter reads the data from `contextUsage` in the `get_session_stats` RPC response and publishes it:

- After creating a session.
- After loading an existing session.
- At the end of every turn, before resolving `session/prompt`.
- After changing the model through either `unstable_setSessionModel` or the `model` configuration option.

The emitted update has the following shape:

```json
{
  "sessionUpdate": "usage_update",
  "used": 4184,
  "size": 272000
}
```

`used` represents the estimated number of tokens in the active context, while `size` represents the selected model's context window. The adapter does not use the session's cumulative token total.

## Motivation

Pi already exposes context occupancy through `get_session_stats`, but the adapter did not communicate it to ACP clients.

As a result, compatible clients could not show how much context remained even though the data was available from the Pi RPC process.

This change connects that information to the standard protocol update without introducing proprietary extensions or new capabilities.

## Implementation

- Added `PiContextUsage` and `PiSessionStats` types at the RPC boundary.
- `getSessionStats()` now returns `Promise<PiSessionStats>` instead of `Promise<unknown>`.
- ACP conversion is centralized in `toContextUsageUpdate`.
- Only safe integers are accepted:
  - `used` must be greater than or equal to zero.
  - `size` must be greater than zero.
- Missing, fractional, non-finite, negative, or unsafe integer values are ignored.
- `tokens: null` does not produce an update. Pi uses this state after compaction until it has another trustworthy estimate.
- The statistics request is best-effort and has a one-second timeout.
- Errors, missing support, or a stalled statistics request never fail or indefinitely delay a session operation.
- At the end of a turn, the usage update is queued and delivered before resolving the prompt and before starting the next queued prompt.
- Cancellation keeps its original `stopReason`; auxiliary reporting does not alter turn semantics.

## Compatibility

- Older Pi versions that do not include `contextUsage` continue to work without errors.
- After compaction, the client may temporarily retain the last known value until a later model response provides a trustworthy token count.
- The adapter does not send `percent`, because clients can derive it from `used / size`.
- The adapter does not send `cost`, because it is not required to represent context occupancy.
- No environment variable or custom capability is added; `usage_update` is already part of ACP.

## Documentation

The README now documents:

- Context-window usage support.
- Delivery through `usage_update`.
- The requirement for a Pi version that exposes `contextUsage`.
- The temporary behavior immediately after compaction.

## Testing

The following checks completed successfully:

```text
npx prettier <PR files> --check
npm run typecheck
npm run lint
npm run test
npm run build
npm run smoke
```

Results:

- 116 tests passed.
- 0 tests failed.
- The Node 22 ESM build completed successfully.
- The ACP smoke test completed initialization, session creation, and a real turn.
- The smoke test received an initial `usage_update` with `used: 0` and `size: 272000`.
- The smoke test received a turn-completion `usage_update` with `used: 4184` and `size: 272000`.
- The final update was delivered before the `session/prompt` response with `stopReason: "end_turn"`.

Added coverage includes:

- Emission after `agent_end`.
- Ordering relative to prompt resolution.
- New and loaded sessions.
- Model changes through both ACP entry points.
- Queued turns.
- Cancellation.
- Missing `contextUsage`.
- `tokens: null` after compaction.
- Negative, fractional, non-finite, and unsafe integer values.
- Failures, missing support, and timeouts from `get_session_stats`.
- ACP notification failures.

## Checklist

- [x] The adapter uses the standard `usage_update` shape.
- [x] `used` represents active context rather than cumulative consumption.
- [x] The final update is delivered before prompt resolution.
- [x] Model changes refresh the context-window size.
- [x] Older Pi versions degrade gracefully.
- [x] No fabricated values are emitted after compaction.
- [x] Auxiliary requests cannot block a turn indefinitely.
- [x] The README is updated.
- [x] Formatting, typecheck, lint, tests, build, and smoke checks pass.
