### PR TITLE
forward session update event

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -822,6 +822,18 @@ export class PiAcpSession {
         break
       }
 
+      case 'session_info_changed': {
+        const name = stringProp(ev, 'name')?.trim()
+        if (name) {
+          this.emit({
+            sessionUpdate: 'session_info_update',
+            title: name,
+            updatedAt: new Date().toISOString()
+          })
+        }
+        break
+      }
+
       case 'turn_end': {
         // pi uses `turn_end` for sub-steps (e.g. tool_use) and will often start another turn.
         // Do NOT resolve the ACP `session/prompt` here; wait for `agent_end`.

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -34,6 +34,30 @@ test('PiAcpSession: emits agent_message_chunk for text_delta', async () => {
   })
 })
 
+test('PiAcpSession: forwards pi session_info_changed as ACP session_info_update', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({ type: 'session_info_changed', name: 'Auto Named Session' })
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 1)
+  assert.equal(conn.updates[0]!.sessionId, 's1')
+  assert.equal(conn.updates[0]!.update.sessionUpdate, 'session_info_update')
+  assert.equal((conn.updates[0]!.update as any).title, 'Auto Named Session')
+  assert.match((conn.updates[0]!.update as any).updatedAt, /^\d{4}-\d{2}-\d{2}T/)
+})
+
 test('PiAcpSession: emits agent_thought_chunk for thinking_delta', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()


### PR DESCRIPTION
This is somewhat related to #25 but is the minimal addition to `pi-acp` needed to implement my own auto-title extension. IMO the full auto-title feature doesn't belong in `pi-acp` so this is the only diff that's relevant.