### PR TITLE
avoid emitting partial tool call locations

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -562,7 +562,7 @@ export class PiAcpSession {
                     }
                   })()
 
-            const locations = toToolCallLocations(rawInput, this.cwd)
+            const locations = ame.type === 'toolcall_end' ? toToolCallLocations(rawInput, this.cwd) : undefined
             const existingStatus = this.currentToolCalls.get(toolCallId)
             // IMPORTANT: never downgrade status (e.g. if we already marked in_progress via tool_execution_start).
             const status = existingStatus ?? 'pending'

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -476,7 +476,7 @@ test('PiAcpSession: preserves ordering when auto_retry_start is interleaved with
   )
 })
 
-test('PiAcpSession: emits streamed tool locations from pi path args', async () => {
+test('PiAcpSession: waits for streamed tool paths to complete before emitting locations', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
 
@@ -489,10 +489,26 @@ test('PiAcpSession: emits streamed tool locations from pi path args', async () =
     fileCommands: []
   })
 
+  const emitToolCall = (type: 'toolcall_start' | 'toolcall_delta', path: string) => {
+    proc.emit({
+      type: 'message_update',
+      assistantMessageEvent: {
+        type,
+        partial: {
+          content: [{ type: 'toolCall', id: 't1', name: 'write', arguments: { path } }]
+        },
+        contentIndex: 0
+      }
+    })
+  }
+
+  emitToolCall('toolcall_start', '/')
+  emitToolCall('toolcall_delta', '/tmp')
+  emitToolCall('toolcall_delta', '/tmp/test.txt')
   proc.emit({
     type: 'message_update',
     assistantMessageEvent: {
-      type: 'toolcall_start',
+      type: 'toolcall_end',
       toolCall: {
         id: 't1',
         name: 'write',
@@ -503,9 +519,13 @@ test('PiAcpSession: emits streamed tool locations from pi path args', async () =
 
   await new Promise(r => setTimeout(r, 0))
 
-  assert.equal(conn.updates.length, 1)
+  assert.equal(conn.updates.length, 4)
   assert.equal(conn.updates[0]!.update.sessionUpdate, 'tool_call')
-  assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: '/tmp/test.txt' }])
+  for (const update of conn.updates.slice(0, -1)) {
+    assert.equal((update.update as any).locations, undefined)
+  }
+  assert.equal(conn.updates[3]!.update.sessionUpdate, 'tool_call_update')
+  assert.deepEqual((conn.updates[3]!.update as any).locations, [{ path: '/tmp/test.txt' }])
 })
 
 test('PiAcpSession: emits edit tool line when oldText matches uniquely', async () => {


### PR DESCRIPTION
Using `pi-acp` I experienced some major issues with Zed getting extremely memory hungry and installing file watchers for pretty much my whole disk. Eventually I tracked the issue down to Zed logs like this:

```
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/Users"
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/Users/david"
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/Users/david/Dev"
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/Users/david/Dev"
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/Users/david"
2026-07-20T13:42:48+01:00 ERROR [crates/acp_thread/src/acp_thread.rs:1138] reading bytes of the file "/"
```

from what I can tell from debugging, this was happening when streaming tool call updates from `pi-acp` emitted partial locations before the LLM had finished emitting the tool path. Zed would receive the tool call update and start building worktrees related to the partial path for file analysis.

You could argue it's a Zed (or pi) bug, however it seems unhelpful to emit these partial locations so this is the patch I applied in `pi-acp` to avoid the bug. Happy to move the discussion elsewhere if you think better.