### PR TITLE
Forward Pi's session rename to the ACP client

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -836,6 +836,25 @@ export class PiAcpSession {
         break
       }
 
+      case 'session_info_changed': {
+        // The agent renamed the session in-process -- e.g. an extension tool
+        // such as `set_session_name` calling `pi.setSessionName()`, or the
+        // built-in `set_session_name` RPC command. Pi emits
+        // `session_info_changed` on the RPC event stream; forward it to the
+        // ACP client as a `session_info_update` carrying the new `title` so
+        // attached UIs (e.g. agent-shell) can refresh the session title /
+        // buffer name live. Mirrors the `/name` slash-command path in agent.ts.
+        const name = typeof (ev as any).name === 'string' ? (ev as any).name.trim() : ''
+        if (name) {
+          this.emit({
+            sessionUpdate: 'session_info_update',
+            title: name,
+            updatedAt: new Date().toISOString()
+          })
+        }
+        break
+      }
+
       case 'agent_settled': {
         // Ensure all updates derived from pi events are delivered before we resolve
         // the ACP `session/prompt` request.


### PR DESCRIPTION
## The PR in one paragraph

When Pi renames its own session, that new name never reaches the connected editor; this PR delivers it, so a client like agent-shell (Emacs) can show the up-to-date session title live.

## Background in simple terms

`pi-acp` is an adapter that sits between the Pi coding agent and any ACP client (for example agent-shell running inside Emacs, or Zed). Pi speaks its own protocol on one side; the editor speaks ACP on the other. `pi-acp`'s job is to listen to what Pi announces and translate each announcement into the equivalent ACP message the editor understands.

Pi can give the current session a human-friendly name. This can happen in several ways:

- the user types the `/name` command,
- the RPC `set_session_name` command is sent, or
- an extension calls `pi.setSessionName()` on Pi's behalf — for instance a small tool that lets the agent name the session itself once it figures out what the work is about.

Whenever any of these happens, Pi broadcasts a `session_info_changed` announcement on its side of the connection.

## The problem

`pi-acp` was not listening for that particular announcement.

Before this PR, `pi-acp` translated Pi's announcements using a big dispatch that handles many event types (assistant text, tool calls, retries, compaction, and so on), but it had no branch for `session_info_changed`. So that event simply fell through and was dropped. The editor was never told the name had changed.

The odd part: `pi-acp` already knew how to tell the editor about a rename. Its own built-in `/name` command explicitly sends the client an ACP `session_info_update` carrying the new title. In other words, the "tell the client" half already existed — only the other half about "the agent running in Pi having renamed itself" was missing. As a result, a rename that came from the agent or an extension (rather than from `pi-acp`'s own `/name` handler) went unnoticed by the client.

This situation is easy to find in practice. A natural quality-of-life setup is to let the agent name its session after it understands the task, and have the editor reflect that name in the buffer/tab title. Without this fix, the agent renames the session, Pi announces it, and the editor never hears about it.

## The fix

Add the one missing branch. When `pi-acp` sees Pi's `session_info_changed` announcement, it now forwards the new name to the client as an ACP `session_info_update` — exactly the same message the existing `/name` command already sends. Empty names are ignored.

That's the whole change: a small case added to the event dispatch, mirroring behavior that was already there for `/name`.

## What this enables

Any rename — from `/name`, from the RPC command, or from an extension calling `pi.setSessionName()` — now reaches the connected editor immediately. Concretely, a client such as agent-shell can update its session title (and, if it chooses, the buffer/tab name) the moment the agent renames the session, without the user lifting a finger.

## Risk

Low. The change only *adds* handling for an event that was previously ignored; no existing behavior is altered. The forwarded message reuses the same `session_info_update` shape the codebase already sends from the `/name` path, so clients that already understand `/name` renames need no changes. A double announcement (once from `/name`'s own handler, once from the newly handled event) is harmless: both carry the same title, and applying it twice is a no-op.

## A natural follow-up

That harmless double announcement mentioned in the previous paragraph hints at a nice simplification. Now that `pi-acp` reacts to Pi's `session_info_changed` at the source, the `/name` command no longer needs to announce the rename itself: the event path already does it for every rename, whether it came from `/name`, the RPC command, or an extension. So the manual `session_info_update` that `/name` sends could simply be removed, leaving a single code path responsible for telling the client. That feels like the right end state.

I have deliberately left that out of this PR to keep the change small and cautious. Removing the `/name` handler's own emit slightly shifts its timing (the client would be notified when the event arrives, a beat after the rename call returns, rather than synchronously right after it). I don't think this would cause any inconvenience; however, I preferred a cautious approach and to defer this simplification. Based on the reviewer's feedback, I am happy to remove `session_info_update` emitted by `/name`.