### PR TITLE
feat(acp): report Pi context window usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Expect some minor breaking changes.
   - Loads file-based slash commands compatible with pi’s conventions
   - Adds a small set of built-in commands for headless/editor usage
   - Supports skill commands (if enabled in pi settings, they appear as `/skill:skill-name` in the ACP client)
+- Context window usage
+  - Reports pi's real context occupancy (`get_session_stats` → `contextUsage`) to the client as ACP `usage_update` after each turn, on `session/new` and `session/load`, and after a model switch
+  - Requires a pi version whose `get_session_stats` response includes `contextUsage`; otherwise no usage is reported
+  - Right after compaction pi may not have a trustworthy token count yet, so the client keeps the previous value until the next model response
 - Skills are loaded by pi directly and are available in ACP sessions
 - (Zed) `pi-acp` emits “startup info” block into the session (pi version, context, skills, prompts, extensions - similar to `pi` in the terminal). You can disable it by setting `quietStartup: true` in pi settings (`~/.pi/agent/settings.json` or `<project>/.pi/settings.json`). When `quietStartup` is enabled, `pi-acp` will still emit a 'New version available' message if the installed pi version is outdated.
 - (Zed) Session history is supported in Zed starting with [`v0.225.0`](https://zed.dev/releases/preview/0.225.0). Session loading / history maps to pi's session files. Sessions can be resumed both in `pi` and in the ACP client.

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -397,6 +397,10 @@ export class PiAcpAgent implements ACPAgent {
     // So we must send this *after* the session/new response has been delivered.
     setTimeout(() => {
       void (async () => {
+        // Publish real context usage now that the client knows the sessionId (clients ignore
+        // notifications for unknown sessions), so the window size is correct before the first prompt.
+        await session.publishContextUsage()
+
         try {
           const pi = (await session.proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -476,7 +480,7 @@ export class PiAcpAgent implements ACPAgent {
       }
 
       if (cmd === 'session') {
-        const stats = (await session.proc.getSessionStats()) as any
+        const stats = await session.proc.getSessionStats()
 
         const lines: string[] = []
         if (stats?.sessionId) lines.push(`Session: ${stats.sessionId}`)
@@ -1076,6 +1080,8 @@ export class PiAcpAgent implements ACPAgent {
     // Advertise slash commands after the response so the client knows the session exists.
     setTimeout(() => {
       void (async () => {
+        await session.publishContextUsage()
+
         try {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -1138,6 +1144,7 @@ export class PiAcpAgent implements ACPAgent {
     const session = await this.restoreSession(params.sessionId)
     await setSessionModel(session.proc, params.modelId)
     await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    await session.publishContextUsage()
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1167,6 +1174,7 @@ export class PiAcpAgent implements ACPAgent {
   async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
     const session = await this.restoreSession(params.sessionId)
     const configId = String(params.configId)
+    let modelChanged = false
 
     if (typeof params.value !== 'string') {
       throw RequestError.invalidParams(`Expected string value for config option: ${configId}`)
@@ -1174,6 +1182,7 @@ export class PiAcpAgent implements ACPAgent {
 
     if (configId === MODEL_CONFIG_ID) {
       await setSessionModel(session.proc, params.value)
+      modelChanged = true
     } else if (configId === THOUGHT_LEVEL_CONFIG_ID) {
       if (!isThinkingLevel(params.value)) {
         throw RequestError.invalidParams(`Unknown thinking level: ${params.value}`)
@@ -1193,6 +1202,8 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    // A different model can mean a different context window; refresh it immediately.
+    if (modelChanged) await session.publishContextUsage()
     return { configOptions }
   }
 }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -11,7 +11,7 @@ import type {
 import { RequestError } from '@agentclientprotocol/sdk'
 import { readFileSync } from 'node:fs'
 import { isAbsolute, resolve as resolvePath } from 'node:path'
-import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent } from '../pi-rpc/process.js'
+import { PiRpcProcess, PiRpcSpawnError, type PiRpcEvent, type PiSessionStats } from '../pi-rpc/process.js'
 import { maybeAuthRequiredError } from './auth-required.js'
 import { SessionStore } from './session-store.js'
 import { expandSlashCommand, type FileSlashCommand } from './slash-commands.js'
@@ -58,6 +58,21 @@ const CONFIRM_PERMISSION_OPTIONS: PermissionOption[] = [
 ]
 const EXTENSION_UI_RAW_INPUT_KEYS = ['title', 'message', 'options', 'placeholder', 'prefill'] as const
 const CHOICE_OPTION_PREFIX = 'choice-'
+
+/**
+ * Map pi's `stats.contextUsage` to an ACP `usage_update`. Returns null whenever pi
+ * reports no trustworthy token count (e.g. `tokens: null` right after compaction) or
+ * the values are not usable integers.
+ */
+function toUsageUpdate(stats: PiSessionStats | null | undefined): SessionUpdate | null {
+  const used = stats?.contextUsage?.tokens
+  const size = stats?.contextUsage?.contextWindow
+
+  if (typeof used !== 'number' || !Number.isSafeInteger(used) || used < 0) return null
+  if (typeof size !== 'number' || !Number.isSafeInteger(size) || size <= 0) return null
+
+  return { sessionUpdate: 'usage_update', used, size }
+}
 
 function findUniqueLineNumber(text: string, needle: string): number | undefined {
   if (!needle) return undefined
@@ -415,6 +430,52 @@ export class PiAcpSession {
 
   private async flushEmits(): Promise<void> {
     await this.lastEmit
+  }
+
+  /**
+   * Best-effort: publish the real pi context-window occupancy as ACP `usage_update`.
+   * Queued updates are flushed even when the stats query fails or times out, so callers
+   * can await this before resolving `session/prompt`.
+   */
+  async publishContextUsage(): Promise<void> {
+    try {
+      // Older/stubbed pi processes may not expose the stats RPC at all.
+      // The request itself times out (see `PiRpcProcess.getSessionStats`).
+      if (typeof this.proc.getSessionStats === 'function') {
+        const update = toUsageUpdate(await this.proc.getSessionStats())
+        if (update) this.emit(update)
+      }
+    } catch {
+      // Context usage is auxiliary; never fail or delay the turn because of it.
+    }
+
+    await this.flushEmits()
+  }
+
+  private async settleTurn(): Promise<void> {
+    // Ensure all updates derived from pi events (plus the final usage update) are
+    // delivered before we resolve the ACP `session/prompt` request.
+    await this.publishContextUsage()
+
+    const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
+    this.pendingTurn?.resolve(reason)
+    this.pendingTurn = null
+    this.inAgentLoop = false
+
+    // Start next queued prompt, if any.
+    const next = this.turnQueue.shift()
+    if (next) {
+      this.emit({
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
+      })
+      this.startTurn(next)
+    } else {
+      this.emit({
+        sessionUpdate: 'session_info_update',
+        _meta: { piAcp: { queueDepth: 0, running: false } }
+      })
+    }
   }
 
   private emitBashToolCall(params: {
@@ -837,29 +898,7 @@ export class PiAcpSession {
       }
 
       case 'agent_settled': {
-        // Ensure all updates derived from pi events are delivered before we resolve
-        // the ACP `session/prompt` request.
-        void this.flushEmits().finally(() => {
-          const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
-          this.pendingTurn?.resolve(reason)
-          this.pendingTurn = null
-          this.inAgentLoop = false
-
-          // Start next queued prompt, if any.
-          const next = this.turnQueue.shift()
-          if (next) {
-            this.emit({
-              sessionUpdate: 'agent_message_chunk',
-              content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
-            })
-            this.startTurn(next)
-          } else {
-            this.emit({
-              sessionUpdate: 'session_info_update',
-              _meta: { piAcp: { queueDepth: 0, running: false } }
-            })
-          }
-        })
+        void this.settleTurn()
         break
       }
 

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -68,6 +68,36 @@ type PiExtensionUiResponse =
 
 export type PiRpcEvent = Record<string, unknown>
 
+/**
+ * `get_session_stats` is auxiliary (context-window reporting): it must never keep a
+ * prompt or a session/new response from completing.
+ */
+export const SESSION_STATS_TIMEOUT_MS = 1_000
+
+/**
+ * Shape of `stats.contextUsage` in pi's `get_session_stats` response.
+ * `tokens` is null while pi has no trustworthy token count (e.g. right after compaction).
+ */
+export type PiContextUsage = {
+  tokens?: number | null
+  contextWindow?: number | null
+}
+
+export type PiSessionStats = {
+  sessionId?: string
+  sessionFile?: string
+  totalMessages?: number
+  cost?: number
+  tokens?: {
+    input?: number
+    output?: number
+    cacheRead?: number
+    cacheWrite?: number
+    total?: number
+  }
+  contextUsage?: PiContextUsage | null
+}
+
 type SpawnParams = {
   cwd: string
   /** Optional override for `pi` executable name/path */
@@ -101,14 +131,10 @@ export class PiRpcProcess {
 
       if (msg?.type === 'response') {
         const id = typeof msg.id === 'string' ? msg.id : undefined
-        if (id) {
-          const pending = this.pending.get(id)
-          if (pending) {
-            this.pending.delete(id)
-            pending.resolve(msg as PiRpcResponse)
-            return
-          }
-        }
+        // `resolve` removes the pending entry. Responses for unknown or already timed-out
+        // ids are dropped: a response is never a pi event, so it must not be broadcast.
+        if (id !== undefined) this.pending.get(id)?.resolve(msg as PiRpcResponse)
+        return
       }
 
       for (const h of this.eventHandlers) h(msg as PiRpcEvent)
@@ -284,10 +310,13 @@ export class PiRpcProcess {
     if (!res.success) throw new Error(`pi set_auto_compaction failed: ${res.error ?? JSON.stringify(res.data)}`)
   }
 
-  async getSessionStats(): Promise<unknown> {
-    const res = await this.request({ type: 'get_session_stats' })
+  /**
+   * @param timeoutMs Request timeout. Defaults to the production value; tests may shorten it.
+   */
+  async getSessionStats(timeoutMs: number = SESSION_STATS_TIMEOUT_MS): Promise<PiSessionStats> {
+    const res = await this.request({ type: 'get_session_stats' }, { timeoutMs })
     if (!res.success) throw new Error(`pi get_session_stats failed: ${res.error ?? JSON.stringify(res.data)}`)
-    return res.data
+    return (res.data ?? {}) as PiSessionStats
   }
 
   async setSessionName(name: string): Promise<void> {
@@ -323,17 +352,49 @@ export class PiRpcProcess {
     await this.writeLine(`${JSON.stringify({ type: 'extension_ui_response', ...response })}\n`)
   }
 
-  private request(cmd: PiRpcCommand): Promise<PiRpcResponse> {
+  private request(cmd: PiRpcCommand, opts?: { timeoutMs?: number }): Promise<PiRpcResponse> {
     const id = crypto.randomUUID()
     const withId = { ...cmd, id }
+    const timeoutMs = opts?.timeoutMs
 
     const line = `${JSON.stringify(withId)}\n`
 
     return new Promise<PiRpcResponse>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject })
+      let timer: ReturnType<typeof setTimeout> | undefined
+
+      // Returns false when the id was already dropped (e.g. by the timeout), so the
+      // caller can avoid settling the promise twice.
+      const drop = (): boolean => {
+        if (timer !== undefined) {
+          clearTimeout(timer)
+          timer = undefined
+        }
+        return this.pending.delete(id)
+      }
+
+      this.pending.set(id, {
+        resolve: res => {
+          drop()
+          resolve(res)
+        },
+        reject: error => {
+          drop()
+          reject(error)
+        }
+      })
+
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          timer = undefined
+          if (!this.pending.delete(id)) return
+          reject(new Error(`pi ${cmd.type} timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+        // Never let an auxiliary request keep the event loop alive.
+        timer.unref?.()
+      }
 
       void this.writeLine(line).catch(error => {
-        this.pending.delete(id)
+        if (!drop()) return
         reject(error)
       })
     })

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -900,3 +900,203 @@ test('PiAcpSession: defaults notify severity to info when notifyType is absent',
     piAcp: { notify: { level: 'info' } }
   })
 })
+
+test('PiAcpSession: emits usage_update from contextUsage before resolving prompt on agent_settled', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    tokens: { total: 999_999 },
+    contextUsage: { tokens: 12_345, contextWindow: 200_000 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  // Block delivery of usage_update to prove the prompt only resolves once it landed.
+  let usageDeliveryStarted: () => void
+  const deliveryStarted = new Promise<void>(resolve => {
+    usageDeliveryStarted = resolve
+  })
+  let releaseDelivery: () => void
+  const deliveryBlocked = new Promise<void>(resolve => {
+    releaseDelivery = resolve
+  })
+
+  const originalSessionUpdate = conn.sessionUpdate.bind(conn)
+  conn.sessionUpdate = async msg => {
+    if (msg.update.sessionUpdate === 'usage_update') {
+      usageDeliveryStarted()
+      await deliveryBlocked
+    }
+    await originalSessionUpdate(msg)
+  }
+
+  let resolved = false
+  const p = session.prompt('hello').then(reason => {
+    resolved = true
+    return reason
+  })
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
+
+  await deliveryStarted
+  assert.equal(resolved, false)
+  releaseDelivery!()
+
+  assert.equal(await p, 'end_turn')
+  assert.equal(proc.getSessionStatsCount, 1)
+  assert.deepEqual(
+    conn.updates.filter(u => u.update.sessionUpdate === 'usage_update').map(u => u.update),
+    [{ sessionUpdate: 'usage_update', used: 12_345, size: 200_000 }]
+  )
+})
+
+test('PiAcpSession: skips usage_update when contextUsage tokens are null', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    tokens: { total: 4_000 },
+    contextUsage: { tokens: null, contextWindow: 200_000 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await p, 'end_turn')
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: skips usage_update for invalid contextUsage values', async () => {
+  const invalid = [
+    { name: 'missing contextUsage', contextUsage: undefined },
+    { name: 'negative tokens', contextUsage: { tokens: -1, contextWindow: 100 } },
+    { name: 'fractional tokens', contextUsage: { tokens: 1.5, contextWindow: 100 } },
+    { name: 'NaN tokens', contextUsage: { tokens: Number.NaN, contextWindow: 100 } },
+    { name: 'zero contextWindow', contextUsage: { tokens: 10, contextWindow: 0 } },
+    { name: 'negative contextWindow', contextUsage: { tokens: 10, contextWindow: -1 } },
+    { name: 'fractional contextWindow', contextUsage: { tokens: 10, contextWindow: 100.5 } },
+    { name: 'null contextWindow', contextUsage: { tokens: 10, contextWindow: null } },
+    { name: 'infinite contextWindow', contextUsage: { tokens: 10, contextWindow: Number.POSITIVE_INFINITY } }
+  ]
+
+  for (const { name, contextUsage } of invalid) {
+    const conn = new FakeAgentSideConnection()
+    const proc = new FakePiRpcProcess()
+    proc.sessionStats = { contextUsage } as any
+
+    const session = new PiAcpSession({
+      sessionId: 's1',
+      cwd: process.cwd(),
+      mcpServers: [],
+      proc: proc as any,
+      conn: asAgentConn(conn),
+      fileCommands: []
+    })
+
+    const p = session.prompt('hello')
+    proc.emit({ type: 'agent_settled' })
+
+    assert.equal(await p, 'end_turn', name)
+    assert.equal(
+      conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+      false,
+      name
+    )
+  }
+})
+
+test('PiAcpSession: get_session_stats rejection does not break the prompt', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStatsError = new Error('pi get_session_stats failed: unsupported')
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await p, 'end_turn')
+  assert.equal(proc.getSessionStatsCount, 1)
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: get_session_stats timeout does not block the prompt', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  // The timeout lives in PiRpcProcess.request (see test/unit/pi-rpc-request-timeout.test.ts);
+  // from the session's point of view it surfaces as a rejection.
+  proc.sessionStatsError = new Error('pi get_session_stats timed out after 1000ms')
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await p, 'end_turn')
+  assert.equal(proc.getSessionStatsCount, 1)
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpSession: cancelled turn still reports cancelled after usage publish', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = { contextUsage: { tokens: 42, contextWindow: 100 } }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const p = session.prompt('hello')
+  await session.cancel()
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await p, 'cancelled')
+  assert.deepEqual(
+    conn.updates.filter(u => u.update.sessionUpdate === 'usage_update').map(u => u.update),
+    [{ sessionUpdate: 'usage_update', used: 42, size: 100 }]
+  )
+})

--- a/test/component/session-list-and-load.test.ts
+++ b/test/component/session-list-and-load.test.ts
@@ -88,6 +88,7 @@ test('PiAcpAgent: listSessions lists pi sessions and loadSession replays history
             { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] }
           ]
         }),
+        getSessionStats: async () => ({ contextUsage: { tokens: 12_345, contextWindow: 200_000 } }),
         getAvailableModels: async () => ({ models: [] }),
         getState: async () => ({ thinkingLevel: 'medium' })
       } as any
@@ -104,6 +105,19 @@ test('PiAcpAgent: listSessions lists pi sessions and loadSession replays history
 
       assert.ok(texts.some(t => t.kind === 'user_message_chunk' && t.text === 'Hello'))
       assert.ok(texts.some(t => t.kind === 'agent_message_chunk' && t.text === 'Hi there!'))
+
+      // loadSession schedules the usage publish after returning (client must know the sessionId first).
+      assert.equal(
+        conn.updates.some(u => (u as any).update?.sessionUpdate === 'usage_update'),
+        false
+      )
+      await new Promise(r => setTimeout(r, 0))
+      await new Promise(r => setTimeout(r, 0))
+
+      assert.deepEqual(
+        conn.updates.filter(u => (u as any).update?.sessionUpdate === 'usage_update'),
+        [{ sessionId: 'sess-1', update: { sessionUpdate: 'usage_update', used: 12_345, size: 200_000 } }]
+      )
     } finally {
       PiRpcProcess.spawn = originalSpawn
     }

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -1,5 +1,5 @@
 import type { AgentSideConnection } from '@agentclientprotocol/sdk'
-import type { PiRpcEvent } from '../../src/pi-rpc/process.js'
+import type { PiRpcEvent, PiSessionStats } from '../../src/pi-rpc/process.js'
 
 type SessionUpdateMsg = Parameters<AgentSideConnection['sessionUpdate']>[0]
 
@@ -29,6 +29,11 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   abortCount = 0
+  getSessionStatsCount = 0
+
+  sessionStats: PiSessionStats = {}
+  /** When set, `getSessionStats()` rejects with this error. */
+  sessionStatsError: unknown = null
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
     this.handlers.push(handler)
@@ -63,6 +68,12 @@ export class FakePiRpcProcess {
 
   async getMessages(): Promise<any> {
     return { messages: [] }
+  }
+
+  async getSessionStats(): Promise<PiSessionStats> {
+    this.getSessionStatsCount += 1
+    if (this.sessionStatsError) throw this.sessionStatsError
+    return this.sessionStats
   }
 }
 

--- a/test/unit/context-usage.test.ts
+++ b/test/unit/context-usage.test.ts
@@ -1,0 +1,184 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpAgent } from '../../src/acp/agent.js'
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+class FakeSessions {
+  constructor(private readonly session: any) {}
+
+  async create() {
+    return this.session
+  }
+
+  maybeGet(sessionId: string) {
+    if (sessionId !== this.session.sessionId) return undefined
+    return this.session
+  }
+
+  get(sessionId: string) {
+    if (sessionId !== this.session.sessionId) {
+      throw new Error(`Unknown sessionId: ${sessionId}`)
+    }
+    return this.session
+  }
+}
+
+/** Let the `setTimeout(..., 0)` continuations scheduled after session/new or session/load run. */
+async function drainScheduledWork(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function makeSession(proc: FakePiRpcProcess, conn: FakeAgentSideConnection): PiAcpSession {
+  return new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+}
+
+test('PiAcpAgent: newSession publishes context usage only after the response is returned', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = { contextUsage: { tokens: 1_234, contextWindow: 100_000 } }
+  const session = makeSession(proc, conn)
+
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  const result = await agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any)
+  assert.equal(result.sessionId, 's1')
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+
+  await drainScheduledWork()
+
+  assert.deepEqual(
+    conn.updates.filter(u => u.update.sessionUpdate === 'usage_update'),
+    [{ sessionId: 's1', update: { sessionUpdate: 'usage_update', used: 1_234, size: 100_000 } }]
+  )
+})
+
+test('PiAcpAgent: newSession tolerates a failing get_session_stats', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStatsError = new Error('pi get_session_stats failed: unsupported')
+  const session = makeSession(proc, conn)
+
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  const result = await agent.newSession({ cwd: process.cwd(), mcpServers: [] } as any)
+  assert.equal(result.sessionId, 's1')
+
+  await drainScheduledWork()
+
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})
+
+test('PiAcpAgent: switching the model config option refreshes context usage', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const state: { thinkingLevel: string; model: { provider: string; id: string } } = {
+    thinkingLevel: 'medium',
+    model: { provider: 'test', id: 'alpha' }
+  }
+  proc.getAvailableModels = async () => ({
+    models: [
+      { provider: 'test', id: 'alpha', name: 'Alpha' },
+      { provider: 'test', id: 'beta', name: 'Beta' }
+    ]
+  })
+  proc.getState = async () => state
+  ;(proc as any).setModel = async (provider: string, modelId: string) => {
+    state.model = { provider, id: modelId }
+    proc.sessionStats = { contextUsage: { tokens: 500, contextWindow: modelId === 'beta' ? 200_000 : 100_000 } }
+  }
+  proc.sessionStats = { contextUsage: { tokens: 500, contextWindow: 100_000 } }
+
+  const session = makeSession(proc, conn)
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  await agent.setSessionConfigOption({ sessionId: 's1', configId: 'model', value: 'test/beta' } as any)
+
+  assert.deepEqual(
+    conn.updates.map(u => u.update.sessionUpdate),
+    ['config_option_update', 'usage_update']
+  )
+  assert.deepEqual(conn.updates.at(-1), {
+    sessionId: 's1',
+    update: { sessionUpdate: 'usage_update', used: 500, size: 200_000 }
+  })
+})
+
+test('PiAcpAgent: unstable_setSessionModel refreshes context usage', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const state: { thinkingLevel: string; model: { provider: string; id: string } } = {
+    thinkingLevel: 'medium',
+    model: { provider: 'test', id: 'alpha' }
+  }
+  proc.getAvailableModels = async () => ({
+    models: [
+      { provider: 'test', id: 'alpha', name: 'Alpha' },
+      { provider: 'test', id: 'beta', name: 'Beta' }
+    ]
+  })
+  proc.getState = async () => state
+  ;(proc as any).setModel = async (provider: string, modelId: string) => {
+    state.model = { provider, id: modelId }
+    proc.sessionStats = { contextUsage: { tokens: 700, contextWindow: modelId === 'beta' ? 200_000 : 100_000 } }
+  }
+  proc.sessionStats = { contextUsage: { tokens: 700, contextWindow: 100_000 } }
+
+  const session = makeSession(proc, conn)
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  await agent.unstable_setSessionModel({ sessionId: 's1', modelId: 'test/beta' })
+
+  assert.equal(proc.getSessionStatsCount, 1)
+  assert.deepEqual(
+    conn.updates.map(u => u.update.sessionUpdate),
+    ['config_option_update', 'usage_update']
+  )
+  assert.deepEqual(conn.updates.at(-1), {
+    sessionId: 's1',
+    update: { sessionUpdate: 'usage_update', used: 700, size: 200_000 }
+  })
+})
+
+test('PiAcpAgent: switching the thinking level does not publish context usage', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const state: { thinkingLevel: string; model: { provider: string; id: string } } = {
+    thinkingLevel: 'medium',
+    model: { provider: 'test', id: 'alpha' }
+  }
+  proc.getState = async () => state
+  ;(proc as any).setThinkingLevel = async (level: string) => {
+    state.thinkingLevel = level
+  }
+  proc.sessionStats = { contextUsage: { tokens: 500, contextWindow: 100_000 } }
+
+  const session = makeSession(proc, conn)
+  const agent = new PiAcpAgent(asAgentConn(conn), {} as any)
+  ;(agent as any).sessions = new FakeSessions(session) as any
+
+  await agent.setSessionConfigOption({ sessionId: 's1', configId: 'thought_level', value: 'high' } as any)
+
+  assert.equal(proc.getSessionStatsCount, 0)
+  assert.equal(
+    conn.updates.some(u => u.update.sessionUpdate === 'usage_update'),
+    false
+  )
+})

--- a/test/unit/pi-rpc-request-timeout.test.ts
+++ b/test/unit/pi-rpc-request-timeout.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { PiRpcProcess, SESSION_STATS_TIMEOUT_MS } from '../../src/pi-rpc/process.js'
+
+type FakeChild = {
+  child: any
+  stdout: PassThrough
+  written: string[]
+}
+
+function makeFakeChild(): FakeChild {
+  const stdout = new PassThrough()
+  const written: string[] = []
+  const child: any = new EventEmitter()
+  child.stdout = stdout
+  child.stderr = new PassThrough()
+  child.killed = false
+  child.kill = () => {}
+  child.stdin = {
+    write: (line: string, cb?: (error?: Error | null) => void) => {
+      written.push(String(line))
+      cb?.(null)
+      return true
+    }
+  }
+  return { child, stdout, written }
+}
+
+// The constructor is private in TS only; tests drive it directly to avoid spawning `pi`.
+function makeProcess(child: any): PiRpcProcess {
+  return new (PiRpcProcess as unknown as new (c: any) => PiRpcProcess)(child)
+}
+
+function pendingSize(proc: PiRpcProcess): number {
+  return (proc as unknown as { pending: Map<string, unknown> }).pending.size
+}
+
+function writeLine(stdout: PassThrough, msg: unknown): Promise<void> {
+  stdout.write(`${JSON.stringify(msg)}\n`)
+  return new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)))
+}
+
+test('PiRpcProcess: getSessionStats defaults to the production timeout', () => {
+  assert.equal(SESSION_STATS_TIMEOUT_MS, 1_000)
+})
+
+test('PiRpcProcess: request timeout rejects, clears pending, and swallows the late response', async () => {
+  const { child, stdout, written } = makeFakeChild()
+  const proc = makeProcess(child)
+
+  const events: unknown[] = []
+  proc.onEvent(ev => events.push(ev))
+
+  await assert.rejects(proc.getSessionStats(5), /pi get_session_stats timed out after 5ms/)
+  assert.equal(pendingSize(proc), 0)
+
+  const sent = JSON.parse(written[0]) as { id: string; type: string }
+  assert.equal(sent.type, 'get_session_stats')
+
+  await writeLine(stdout, {
+    type: 'response',
+    id: sent.id,
+    command: 'get_session_stats',
+    success: true,
+    data: { contextUsage: { tokens: 1, contextWindow: 2 } }
+  })
+
+  assert.deepEqual(events, [])
+  assert.equal(pendingSize(proc), 0)
+})
+
+test('PiRpcProcess: response before the timeout resolves and clears pending', async () => {
+  const { child, stdout, written } = makeFakeChild()
+  const proc = makeProcess(child)
+
+  const events: unknown[] = []
+  proc.onEvent(ev => events.push(ev))
+
+  const p = proc.getSessionStats(5_000)
+  const sent = JSON.parse(written[0]) as { id: string }
+
+  await writeLine(stdout, {
+    type: 'response',
+    id: sent.id,
+    command: 'get_session_stats',
+    success: true,
+    data: { contextUsage: { tokens: 10, contextWindow: 100 } }
+  })
+
+  assert.deepEqual(await p, { contextUsage: { tokens: 10, contextWindow: 100 } })
+  assert.equal(pendingSize(proc), 0)
+  assert.deepEqual(events, [])
+})
+
+test('PiRpcProcess: responses with unknown ids are dropped while real events are delivered', async () => {
+  const { child, stdout } = makeFakeChild()
+  const proc = makeProcess(child)
+
+  const events: unknown[] = []
+  proc.onEvent(ev => events.push(ev))
+
+  await writeLine(stdout, { type: 'response', id: 'nope', command: 'get_state', success: true, data: {} })
+  await writeLine(stdout, { type: 'response', command: 'get_state', success: true, data: {} })
+  await writeLine(stdout, { type: 'agent_start' })
+
+  assert.deepEqual(events, [{ type: 'agent_start' }])
+})

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -121,6 +121,9 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
         setModelCalls.push({ provider, modelId })
         state.model = { provider, id: modelId }
       }
+    },
+    async publishContextUsage() {
+      // Context usage publishing is covered in test/unit/context-usage.test.ts.
     }
   }
 

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -129,7 +129,10 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
   const sessions = new FakeSessions((sessionId, params) => ({
     sessionId,
     cwd: params.cwd,
-    proc: params.proc
+    proc: params.proc,
+    async publishContextUsage() {
+      // Context usage publishing is covered in test/unit/context-usage.test.ts.
+    }
   }))
 
   const originalSpawn = PiRpcProcess.spawn


### PR DESCRIPTION
## Summary

Forward Pi's authoritative context-window occupancy through the standard ACP `usage_update` notification.

Pi already exposes the active context via `get_session_stats.contextUsage`, but pi-acp did not forward it. ACP clients therefore had to show no context data or guess from model names and cumulative token totals. This is especially visible for custom/extended-context models (for example, a configured 1M window can be shown as 258K or 200K).

## What changed

- map `contextUsage.tokens` to ACP `used`
- map `contextUsage.contextWindow` to ACP `size`
- publish usage:
  - after `session/new`
  - after `session/load`
  - after model changes
  - after `agent_settled`, before resolving `session/prompt`
- skip updates when Pi reports `tokens: null` or invalid/non-integral values
- never substitute cumulative `tokens.total`
- omit cost because Pi's stats do not carry an explicit currency
- make `get_session_stats` best-effort with a 1s RPC timeout
- remove timed-out requests from the RPC pending map and swallow late responses

The `agent_settled` boundary is important on current main: `agent_end` may be followed by retry, compaction, or queued continuation work.

## Compatibility

Older Pi versions that do not expose `contextUsage` continue to work; no usage update is emitted. Immediately after compaction, Pi may return `tokens: null`, so clients retain the previous reading until a trustworthy estimate is available.

This is a current-main implementation of the behavior discussed in #48, #75, and #87. Those PRs are now conflicting and/or target the older `agent_end` lifecycle.

## Validation

- `npm run format -- --check`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 110 passed, 0 failed
- `npm run build`
- `git diff --check`

A live Pi 0.83 RPC probe returned:

```json
{
  "contextUsage": {
    "tokens": 100,
    "contextWindow": 1000000,
    "percent": 0.01
  }
}
```

The adapter maps that to:

```json
{
  "sessionUpdate": "usage_update",
  "used": 100,
  "size": 1000000
}
```

Tests cover initial/new and loaded sessions, both model-switch entry points, `agent_settled` delivery ordering, cancellation, null/invalid usage, RPC failures/timeouts, pending-request cleanup, and late-response handling.