### PR TITLE
feat: add PI_ACP_DATA_DIR env var for session map location override

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Point your ACP client to the built `dist/index.js`:
 - `PI_ACP_ENABLE_EMBEDDED_CONTEXT=true` advertises ACP `promptCapabilities.embeddedContext` support to the client.
 - Default: unset/any other value means `false`.
 - When disabled, compliant ACP clients should avoid sending embedded `resource` blocks. If they send them anyway, `pi-acp` still degrades gracefully by converting them into plain-text prompt context.
+- `PI_ACP_DATA_DIR` overrides the default location for pi-acp's own data directory (default: `~/.pi/pi-acp`). This controls where the session-map file and any future adapter-owned data is stored. Separate from `PI_CODING_AGENT_DIR`, which rehomes pi's own agent directory.
 
 You can add the environment variable in the Zed settings with:
 

--- a/src/acp/paths.ts
+++ b/src/acp/paths.ts
@@ -1,13 +1,17 @@
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 /**
  * Storage owned by the ACP adapter.
  *
- * We intentionally keep this separate from pi's own ~/.pi/agent/* directory.
+ * Set PI_ACP_DATA_DIR to override the default location (defaults to ~/.pi/pi-acp).
+ * This is separate from pi's own ~/.pi/agent/* directory, which is controlled
+ * via PI_CODING_AGENT_DIR.
  */
 export function getPiAcpDir(): string {
-  return join(homedir(), '.pi', 'pi-acp')
+  return process.env.PI_ACP_DATA_DIR
+    ? resolve(process.env.PI_ACP_DATA_DIR)
+    : join(homedir(), '.pi', 'pi-acp')
 }
 
 export function getPiAcpSessionMapPath(): string {


### PR DESCRIPTION
## Summary

Add support for overriding pi-acp's data directory (session-map.json and any future adapter-owned data) via the `PI_ACP_DATA_DIR` environment variable. Defaults to `~/.pi/pi-acp` when unset.

This is separate from `PI_CODING_AGENT_DIR`, which rehomes pi's own agent directory (`~/.pi/agent`). Previously, session-map.json was hardcoded to `~/.pi/pi-acp/session-map.json` with no override option.

## Changes

- **src/acp/paths.ts**: Added `PI_ACP_DATA_DIR` env var check in `getPiAcpDir()`, following the same pattern already used by `PI_CODING_AGENT_DIR`
- **README.md**: Documented the new env var in the Environment variables section

## Testing

All 95 existing tests pass. The change is backward-compatible (defaults to the previous behavior when unset).