### PR TITLE
feat(acp): forward lean-subagent settlements as PromptResponse _meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Expect some minor breaking changes.
 - Streams assistant output as ACP `agent_message_chunk`
 - Maps pi tool execution to ACP `tool_call` / `tool_call_update`
   - Tool call locations are surfaced when available for ACP clients that support opening the referenced file/context
+- Reports Pi-owned accounting in standard ACP fields for model-backed prompts
+  - Baseline and final `usage_update` notifications carry current context occupancy and cumulative USD cost
+  - `PromptResponse.usage` carries the prompt's input, output, and cache token deltas
+  - Missing or inconsistent Pi statistics are omitted rather than estimated
   - Relative file paths from pi are resolved against the session cwd before being emitted as ACP tool locations, which enables follow-along features in clients like Zed
   - For `edit`, `pi-acp` attempts to infer a 1-based line number from a unique `oldText` match in the pre-edit file snapshot and includes it in the emitted tool location when possible
   - For `edit`, `pi-acp` snapshots the file before the tool runs and emits an ACP **structured diff** (`oldText`/`newText`) on completion when possible
@@ -197,6 +201,7 @@ Project layout:
 - No ACP filesystem delegation (`fs/*`) and no ACP terminal delegation (`terminal/*`). pi reads/writes and executes locally.
 - MCP servers are accepted in ACP params and stored in session state, but not wired through to pi in this adapter. If you use [pi MCP adapter](https://github.com/nicobailon/pi-mcp-adapter) it will be available in the ACP client.
 - Assistant streaming is currently sent as `agent_message_chunk` (no separate thought stream).
+- Adapter-handled built-in commands do not return `PromptResponse.usage`; model-backed prompts and file-based command expansions do.
 - Queue is implemented client-side and should work like pi's `one-at-a-time`
 - ~~ACP clients don't yet suport session history, but ACP sessions from `pi-acp` can be `/resume`d in pi directly~~
 

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -437,7 +437,10 @@ export class PiAcpAgent implements ACPAgent {
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
     const session = await this.restoreSession(params.sessionId)
+    return this.executePrompt(params, session)
+  }
 
+  private async executePrompt(params: PromptRequest, session: PiAcpSession): Promise<PromptResponse> {
     const { message, images } = promptToPiMessage(params.prompt)
 
     // Built-in ACP slash command handling (headless-friendly subset).
@@ -887,9 +890,9 @@ export class PiAcpAgent implements ACPAgent {
     // ACP StopReason does not include "error"; if pi fails we map to end_turn for now,
     // unless we know this was a cancellation.
     const stopReason: StopReason =
-      result === 'error' ? (session.wasCancelRequested() ? 'cancelled' : 'end_turn') : result
+      result.stopReason === 'error' ? (session.wasCancelRequested() ? 'cancelled' : 'end_turn') : result.stopReason
 
-    return { stopReason }
+    return { stopReason, ...(result.usage ? { usage: result.usage } : {}) }
   }
 
   async cancel(params: CancelNotification): Promise<void> {

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -892,7 +892,11 @@ export class PiAcpAgent implements ACPAgent {
     const stopReason: StopReason =
       result.stopReason === 'error' ? (session.wasCancelRequested() ? 'cancelled' : 'end_turn') : result.stopReason
 
-    return { stopReason, ...(result.usage ? { usage: result.usage } : {}) }
+    return {
+      stopReason,
+      ...(result.usage ? { usage: result.usage } : {}),
+      ...(result._meta ? { _meta: result._meta } : {})
+    }
   }
 
   async cancel(params: CancelNotification): Promise<void> {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -274,6 +274,7 @@ export class PiAcpSession {
   // Current in-flight turn (if any). Additional prompts are queued.
   private pendingTurn: PendingTurn | null = null
   private readonly turnQueue: QueuedTurn[] = []
+  private retryFailureMessage: string | null = null
   // Track tool call statuses and ensure they are monotonic (pending -> in_progress -> completed).
   // Some pi events can arrive out of order (e.g. late toolcall_* deltas after execution starts),
   // and clients may hide progress if we ever downgrade back to `pending`.
@@ -474,6 +475,7 @@ export class PiAcpSession {
   private startTurn(t: QueuedTurn): void {
     this.cancelRequested = false
     this.inAgentLoop = false
+    this.retryFailureMessage = null
 
     this.pendingTurn = { resolve: t.resolve, reject: t.reject }
 
@@ -781,6 +783,7 @@ export class PiAcpSession {
       }
 
       case 'auto_retry_start': {
+        this.retryFailureMessage = null
         this.emit({
           sessionUpdate: 'agent_message_chunk',
           content: { type: 'text', text: formatAutoRetryMessage(ev) } satisfies ContentBlock
@@ -789,9 +792,19 @@ export class PiAcpSession {
       }
 
       case 'auto_retry_end': {
+        const success = (ev as { success?: unknown }).success
+        if (success === false) {
+          this.retryFailureMessage = formatAutoRetryFailureMessage(ev)
+        } else {
+          this.retryFailureMessage = null
+        }
+
         this.emit({
           sessionUpdate: 'agent_message_chunk',
-          content: { type: 'text', text: 'Retry finished, resuming.' } satisfies ContentBlock
+          content: {
+            type: 'text',
+            text: this.retryFailureMessage ?? 'Retry finished, resuming.'
+          } satisfies ContentBlock
         })
         break
       }
@@ -840,10 +853,16 @@ export class PiAcpSession {
         // Ensure all updates derived from pi events are delivered before we resolve
         // the ACP `session/prompt` request.
         void this.flushEmits().finally(() => {
-          const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
-          this.pendingTurn?.resolve(reason)
+          if (this.cancelRequested) {
+            this.pendingTurn?.resolve('cancelled')
+          } else if (this.retryFailureMessage) {
+            this.pendingTurn?.reject(RequestError.internalError({}, this.retryFailureMessage))
+          } else {
+            this.pendingTurn?.resolve('end_turn')
+          }
           this.pendingTurn = null
           this.inAgentLoop = false
+          this.retryFailureMessage = null
 
           // Start next queued prompt, if any.
           const next = this.turnQueue.shift()
@@ -1017,6 +1036,14 @@ function formatAutoRetryMessage(ev: PiRpcEvent): string {
   if (delayMs > 0 && delaySeconds === 0) delaySeconds = 1
 
   return `Retrying (attempt ${attempt}/${maxAttempts}, waiting ${delaySeconds}s)...`
+}
+
+function formatAutoRetryFailureMessage(ev: PiRpcEvent): string {
+  const attempt = Number((ev as { attempt?: unknown }).attempt)
+  if (Number.isSafeInteger(attempt) && attempt > 0) {
+    return `Automatic retries exhausted after ${attempt} attempts.`
+  }
+  return 'Automatic retries exhausted.'
 }
 
 function toToolKind(toolName: string): ToolKind {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -6,7 +6,8 @@ import type {
   SessionUpdate,
   ToolCallContent,
   ToolCallLocation,
-  ToolKind
+  ToolKind,
+  Usage
 } from '@agentclientprotocol/sdk'
 import { RequestError } from '@agentclientprotocol/sdk'
 import { readFileSync } from 'node:fs'
@@ -27,6 +28,13 @@ import {
   isBashTool
 } from './translate/bash.js'
 import { toolResultToText } from './translate/pi-tools.js'
+import {
+  isNonDecreasingUsage,
+  parsePiUsageSnapshot,
+  promptUsageDelta,
+  usageUpdate,
+  type PiUsageSnapshot
+} from './usage.js'
 
 type SessionCreateParams = {
   cwd: string
@@ -38,15 +46,21 @@ type SessionCreateParams = {
 
 export type StopReason = 'end_turn' | 'cancelled' | 'error'
 
+export type SessionPromptResult = {
+  stopReason: StopReason
+  usage?: Usage
+}
+
 type PendingTurn = {
-  resolve: (reason: StopReason) => void
+  resolve: (result: SessionPromptResult) => void
   reject: (err: unknown) => void
+  beforeUsage: PiUsageSnapshot | null
 }
 
 type QueuedTurn = {
   message: string
   images: unknown[]
-  resolve: (reason: StopReason) => void
+  resolve: (result: SessionPromptResult) => void
   reject: (err: unknown) => void
 }
 
@@ -273,6 +287,7 @@ export class PiAcpSession {
 
   // Current in-flight turn (if any). Additional prompts are queued.
   private pendingTurn: PendingTurn | null = null
+  private finishingTurn: PendingTurn | null = null
   private readonly turnQueue: QueuedTurn[] = []
   private retryFailureMessage: string | null = null
   // Track tool call statuses and ensure they are monotonic (pending -> in_progress -> completed).
@@ -335,11 +350,11 @@ export class PiAcpSession {
     })
   }
 
-  async prompt(message: string, images: unknown[] = []): Promise<StopReason> {
+  async prompt(message: string, images: unknown[] = []): Promise<SessionPromptResult> {
     // pi RPC mode disables slash command expansion, so we do it here.
     const expandedMessage = expandSlashCommand(message, this.fileCommands)
 
-    const turnPromise = new Promise<StopReason>((resolve, reject) => {
+    const turnPromise = new Promise<SessionPromptResult>((resolve, reject) => {
       const queued: QueuedTurn = { message: expandedMessage, images, resolve, reject }
 
       // If a turn is already running, enqueue.
@@ -367,7 +382,7 @@ export class PiAcpSession {
       }
 
       // No turn is running; start immediately.
-      this.startTurn(queued)
+      void this.startTurn(queued)
     })
 
     return turnPromise
@@ -379,7 +394,7 @@ export class PiAcpSession {
 
     if (this.turnQueue.length) {
       const queued = this.turnQueue.splice(0, this.turnQueue.length)
-      for (const t of queued) t.resolve('cancelled')
+      for (const t of queued) t.resolve({ stopReason: 'cancelled' })
 
       this.emit({
         sessionUpdate: 'agent_message_chunk',
@@ -472,46 +487,103 @@ export class PiAcpSession {
     this.bashOutputSnapshots.delete(toolCallId)
   }
 
-  private startTurn(t: QueuedTurn): void {
+  private async readUsageSnapshot(): Promise<PiUsageSnapshot | null> {
+    try {
+      return parsePiUsageSnapshot(await this.proc.getSessionStats())
+    } catch {
+      return null
+    }
+  }
+
+  private emitUsageSnapshot(snapshot: PiUsageSnapshot | null): void {
+    if (!snapshot) return
+    const update = usageUpdate(snapshot)
+    if (!update) return
+    this.emit({ sessionUpdate: 'usage_update', ...update })
+  }
+
+  private async startTurn(t: QueuedTurn): Promise<void> {
     this.cancelRequested = false
     this.inAgentLoop = false
     this.retryFailureMessage = null
 
-    this.pendingTurn = { resolve: t.resolve, reject: t.reject }
+    const pending: PendingTurn = { resolve: t.resolve, reject: t.reject, beforeUsage: null }
+    this.pendingTurn = pending
 
-    // Publish queue depth (0 because we're starting the turn now).
     this.emit({
       sessionUpdate: 'session_info_update',
       _meta: { piAcp: { queueDepth: this.turnQueue.length, running: true } }
     })
 
-    // Kick off pi, but completion is determined by pi events, not the RPC response.
-    // The prompt RPC only acknowledges acceptance; retry, compaction, or queued
-    // continuations may emit multiple `agent_end` events before `agent_settled`.
-    this.proc.prompt(t.message, t.images).catch(err => {
-      // If the subprocess errors before we get `agent_settled`, treat as error unless cancelled.
-      // Also ensure we flush any already-enqueued updates first.
-      void this.flushEmits().finally(() => {
-        // If this looks like an auth/config issue, surface AUTH_REQUIRED so clients can offer terminal login.
-        const authErr = maybeAuthRequiredError(err)
-        if (authErr) {
-          this.pendingTurn?.reject(authErr)
-        } else {
-          const reason: StopReason = this.cancelRequested ? 'cancelled' : 'error'
-          this.pendingTurn?.resolve(reason)
-        }
+    pending.beforeUsage = await this.readUsageSnapshot()
+    this.emitUsageSnapshot(pending.beforeUsage)
 
-        this.pendingTurn = null
-        this.inAgentLoop = false
+    if (this.pendingTurn !== pending) return
+    if (this.cancelRequested) {
+      await this.finishTurn({ stopReason: 'cancelled' }, false)
+      return
+    }
 
-        // If the prompt failed, do not automatically proceed—pi may be unhealthy.
-        // But we still clear the queueDepth metadata.
-        this.emit({
-          sessionUpdate: 'session_info_update',
-          _meta: { piAcp: { queueDepth: this.turnQueue.length, running: false } }
-        })
+    // The prompt RPC only acknowledges acceptance; completion is determined by
+    // agent_settled after retries, compaction, and queued continuations finish.
+    void this.proc.prompt(t.message, t.images).catch(async error => {
+      const authError = maybeAuthRequiredError(error)
+      if (authError) {
+        await this.finishTurn({ error: authError }, false)
+        return
+      }
+      await this.finishTurn({ stopReason: this.cancelRequested ? 'cancelled' : 'error' }, false)
+    })
+  }
+
+  private async finishTurn(
+    outcome: { stopReason: StopReason } | { error: unknown },
+    startNext: boolean
+  ): Promise<void> {
+    const pending = this.pendingTurn
+    if (!pending || this.finishingTurn === pending) return
+    this.finishingTurn = pending
+
+    let afterUsage = await this.readUsageSnapshot()
+    if (pending.beforeUsage && afterUsage && !isNonDecreasingUsage(pending.beforeUsage, afterUsage)) {
+      afterUsage = null
+    }
+    this.emitUsageSnapshot(afterUsage)
+    await this.flushEmits()
+
+    if (this.pendingTurn !== pending) return
+
+    const finalOutcome = this.cancelRequested ? ({ stopReason: 'cancelled' } as const) : outcome
+    if ('error' in finalOutcome) {
+      pending.reject(finalOutcome.error)
+    } else {
+      const usage = pending.beforeUsage && afterUsage ? promptUsageDelta(pending.beforeUsage, afterUsage) : null
+      pending.resolve({
+        stopReason: finalOutcome.stopReason,
+        ...(usage ? { usage } : {})
       })
-      void err
+    }
+
+    this.pendingTurn = null
+    this.finishingTurn = null
+    this.inAgentLoop = false
+    this.retryFailureMessage = null
+
+    if (startNext) {
+      const next = this.turnQueue.shift()
+      if (next) {
+        this.emit({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
+        })
+        void this.startTurn(next)
+        return
+      }
+    }
+
+    this.emit({
+      sessionUpdate: 'session_info_update',
+      _meta: { piAcp: { queueDepth: this.turnQueue.length, running: false } }
     })
   }
 
@@ -850,35 +922,12 @@ export class PiAcpSession {
       }
 
       case 'agent_settled': {
-        // Ensure all updates derived from pi events are delivered before we resolve
-        // the ACP `session/prompt` request.
-        void this.flushEmits().finally(() => {
-          if (this.cancelRequested) {
-            this.pendingTurn?.resolve('cancelled')
-          } else if (this.retryFailureMessage) {
-            this.pendingTurn?.reject(RequestError.internalError({}, this.retryFailureMessage))
-          } else {
-            this.pendingTurn?.resolve('end_turn')
-          }
-          this.pendingTurn = null
-          this.inAgentLoop = false
-          this.retryFailureMessage = null
-
-          // Start next queued prompt, if any.
-          const next = this.turnQueue.shift()
-          if (next) {
-            this.emit({
-              sessionUpdate: 'agent_message_chunk',
-              content: { type: 'text', text: `Starting queued message. (${this.turnQueue.length} remaining)` }
-            })
-            this.startTurn(next)
-          } else {
-            this.emit({
-              sessionUpdate: 'session_info_update',
-              _meta: { piAcp: { queueDepth: 0, running: false } }
-            })
-          }
-        })
+        const outcome = this.cancelRequested
+          ? ({ stopReason: 'cancelled' } as const)
+          : this.retryFailureMessage
+            ? ({ error: RequestError.internalError({}, this.retryFailureMessage) } as const)
+            : ({ stopReason: 'end_turn' } as const)
+        void this.finishTurn(outcome, true)
         break
       }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -49,12 +49,14 @@ export type StopReason = 'end_turn' | 'cancelled' | 'error'
 export type SessionPromptResult = {
   stopReason: StopReason
   usage?: Usage
+  _meta?: Record<string, unknown>
 }
 
 type PendingTurn = {
   resolve: (result: SessionPromptResult) => void
   reject: (err: unknown) => void
   beforeUsage: PiUsageSnapshot | null
+  leanSubagentSettlements?: Record<string, unknown>
 }
 
 type QueuedTurn = {
@@ -558,9 +560,12 @@ export class PiAcpSession {
       pending.reject(finalOutcome.error)
     } else {
       const usage = pending.beforeUsage && afterUsage ? promptUsageDelta(pending.beforeUsage, afterUsage) : null
+      const settlements = pending.leanSubagentSettlements
+      pending.leanSubagentSettlements = undefined
       pending.resolve({
         stopReason: finalOutcome.stopReason,
-        ...(usage ? { usage } : {})
+        ...(usage ? { usage } : {}),
+        ...(settlements ? { _meta: { helix: { leanSubagentSettlements: settlements } } } : {})
       })
     }
 
@@ -839,6 +844,20 @@ export class PiAcpSession {
         })
 
         this.cleanupToolCall(toolCallId)
+        break
+      }
+
+      case 'entry_appended': {
+        const entry = (ev as any).entry
+        if (entry?.customType !== 'lean-subagent-settlements' || !this.pendingTurn) break
+
+        const data = entry.data
+        if (!data || typeof data !== 'object' || Array.isArray(data) || (data as any).version !== 1) {
+          console.debug('Ignoring invalid lean-subagent-settlements entry: expected version 1')
+          break
+        }
+
+        this.pendingTurn.leanSubagentSettlements = data as Record<string, unknown>
         break
       }
 

--- a/src/acp/usage.ts
+++ b/src/acp/usage.ts
@@ -1,0 +1,131 @@
+import type { Usage, UsageUpdate } from '@agentclientprotocol/sdk'
+
+type TokenTotals = {
+  input: number
+  output: number
+  total: number
+  cacheRead?: number
+  cacheWrite?: number
+}
+
+export type PiUsageSnapshot = {
+  sessionId: string
+  tokens: TokenTotals
+  cost?: number
+  context?: {
+    tokens: number
+    contextWindow: number
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function cumulativeNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+function optionalCumulativeNumber(value: unknown): number | undefined | null {
+  if (value === undefined || value === null) return undefined
+  return cumulativeNumber(value)
+}
+
+export function parsePiUsageSnapshot(value: unknown): PiUsageSnapshot | null {
+  if (!isRecord(value) || !isRecord(value.tokens)) return null
+
+  const sessionId = typeof value.sessionId === 'string' && value.sessionId.length > 0 ? value.sessionId : null
+  const input = cumulativeNumber(value.tokens.input)
+  const output = cumulativeNumber(value.tokens.output)
+  const total = cumulativeNumber(value.tokens.total)
+  const cacheRead = optionalCumulativeNumber(value.tokens.cacheRead)
+  const cacheWrite = optionalCumulativeNumber(value.tokens.cacheWrite)
+  const cost = optionalCumulativeNumber(value.cost)
+
+  if (
+    sessionId === null ||
+    input === null ||
+    output === null ||
+    total === null ||
+    cacheRead === null ||
+    cacheWrite === null ||
+    cost === null
+  ) {
+    return null
+  }
+  if (cacheRead !== undefined && cacheWrite !== undefined && total !== input + output + cacheRead + cacheWrite) {
+    return null
+  }
+
+  const snapshot: PiUsageSnapshot = {
+    sessionId,
+    tokens: {
+      input,
+      output,
+      total,
+      ...(cacheRead === undefined ? {} : { cacheRead }),
+      ...(cacheWrite === undefined ? {} : { cacheWrite })
+    },
+    ...(cost === undefined ? {} : { cost })
+  }
+
+  if (isRecord(value.contextUsage)) {
+    const contextWindow = cumulativeNumber(value.contextUsage.contextWindow)
+    const contextTokens = cumulativeNumber(value.contextUsage.tokens)
+    if (contextWindow !== null && contextWindow > 0 && contextTokens !== null) {
+      snapshot.context = { tokens: contextTokens, contextWindow }
+    }
+  }
+
+  return snapshot
+}
+
+export function isNonDecreasingUsage(before: PiUsageSnapshot, after: PiUsageSnapshot): boolean {
+  const required =
+    before.sessionId === after.sessionId &&
+    after.tokens.input >= before.tokens.input &&
+    after.tokens.output >= before.tokens.output &&
+    after.tokens.total >= before.tokens.total &&
+    (before.cost === undefined || after.cost === undefined || after.cost >= before.cost)
+
+  if (!required) return false
+
+  for (const key of ['cacheRead', 'cacheWrite'] as const) {
+    const previous = before.tokens[key]
+    const current = after.tokens[key]
+    if (previous !== undefined && current !== undefined && current < previous) return false
+  }
+
+  return true
+}
+
+export function promptUsageDelta(before: PiUsageSnapshot, after: PiUsageSnapshot): Usage | null {
+  if (!isNonDecreasingUsage(before, after)) return null
+
+  const cachedReadTokens =
+    before.tokens.cacheRead === undefined || after.tokens.cacheRead === undefined
+      ? undefined
+      : after.tokens.cacheRead - before.tokens.cacheRead
+  const cachedWriteTokens =
+    before.tokens.cacheWrite === undefined || after.tokens.cacheWrite === undefined
+      ? undefined
+      : after.tokens.cacheWrite - before.tokens.cacheWrite
+
+  return {
+    inputTokens: after.tokens.input - before.tokens.input,
+    outputTokens: after.tokens.output - before.tokens.output,
+    totalTokens: after.tokens.total - before.tokens.total,
+    ...(cachedReadTokens === undefined ? {} : { cachedReadTokens }),
+    ...(cachedWriteTokens === undefined ? {} : { cachedWriteTokens })
+  }
+}
+
+export function usageUpdate(snapshot: PiUsageSnapshot): UsageUpdate | null {
+  if (!snapshot.context) return null
+
+  return {
+    used: snapshot.context.tokens,
+    size: snapshot.context.contextWindow,
+    ...(snapshot.cost === undefined ? {} : { cost: { amount: snapshot.cost, currency: 'USD' } })
+  }
+}

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -17,6 +17,8 @@ export class PiRpcSpawnError extends Error {
 const ESC = String.fromCharCode(0x1b)
 const CSI = String.fromCharCode(0x9b)
 
+const SESSION_STATS_TIMEOUT_MS = 1_000
+
 const ANSI_ESCAPE_REGEX = new RegExp(
   `[${ESC}${CSI}][[\\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]`,
   'g'
@@ -285,7 +287,7 @@ export class PiRpcProcess {
   }
 
   async getSessionStats(): Promise<unknown> {
-    const res = await this.request({ type: 'get_session_stats' })
+    const res = await this.request({ type: 'get_session_stats' }, SESSION_STATS_TIMEOUT_MS)
     if (!res.success) throw new Error(`pi get_session_stats failed: ${res.error ?? JSON.stringify(res.data)}`)
     return res.data
   }
@@ -323,18 +325,37 @@ export class PiRpcProcess {
     await this.writeLine(`${JSON.stringify({ type: 'extension_ui_response', ...response })}\n`)
   }
 
-  private request(cmd: PiRpcCommand): Promise<PiRpcResponse> {
+  private request(cmd: PiRpcCommand, timeoutMs?: number): Promise<PiRpcResponse> {
     const id = crypto.randomUUID()
     const withId = { ...cmd, id }
-
     const line = `${JSON.stringify(withId)}\n`
 
     return new Promise<PiRpcResponse>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject })
+      let timeout: NodeJS.Timeout | undefined
+      const clearRequestTimeout = () => {
+        if (timeout !== undefined) clearTimeout(timeout)
+      }
+      const resolveRequest = (response: PiRpcResponse) => {
+        clearRequestTimeout()
+        resolve(response)
+      }
+      const rejectRequest = (error: unknown) => {
+        clearRequestTimeout()
+        reject(error)
+      }
+
+      this.pending.set(id, { resolve: resolveRequest, reject: rejectRequest })
+      if (timeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          if (this.pending.delete(id)) {
+            rejectRequest(new Error(`pi ${cmd.type} timed out after ${timeoutMs}ms`))
+          }
+        }, timeoutMs)
+      }
 
       void this.writeLine(line).catch(error => {
         this.pending.delete(id)
-        reject(error)
+        rejectRequest(error)
       })
     })
   }

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -382,7 +382,7 @@ test('PiAcpSession: emits agent_message_chunk for auto_retry_end', async () => {
     fileCommands: []
   })
 
-  proc.emit({ type: 'auto_retry_end' } as any)
+  proc.emit({ type: 'auto_retry_end', success: true, attempt: 2 } as any)
 
   await new Promise(r => setTimeout(r, 0))
 
@@ -391,6 +391,42 @@ test('PiAcpSession: emits agent_message_chunk for auto_retry_end', async () => {
     sessionUpdate: 'agent_message_chunk',
     content: { type: 'text', text: 'Retry finished, resuming.' }
   })
+})
+
+test('PiAcpSession: rejects the prompt when automatic retries are exhausted', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({
+    type: 'auto_retry_end',
+    success: false,
+    attempt: 3,
+    finalError: 'Codex error: Our servers are currently overloaded. Please try again later.'
+  } as any)
+  proc.emit({ type: 'agent_end', willRetry: false })
+  proc.emit({ type: 'agent_settled' })
+
+  await assert.rejects(prompt, /automatic retries exhausted after 3 attempts/i)
+
+  const messages = conn.updates
+    .filter(update => update.update.sessionUpdate === 'agent_message_chunk')
+    .map(update => (update.update as any).content.text)
+  assert.deepEqual(messages, ['Automatic retries exhausted after 3 attempts.'])
+  assert.equal(
+    messages.some(message => message.includes('servers are currently overloaded')),
+    false
+  )
 })
 
 test('PiAcpSession: emits agent_message_chunk for auto_compaction_start', async () => {

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -6,6 +6,21 @@ import { join } from 'node:path'
 import { PiAcpSession } from '../../src/acp/session.js'
 import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
 
+function usageStats(input: number, output: number, cost: number) {
+  return {
+    sessionId: 's1',
+    tokens: {
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: input + output
+    },
+    cost,
+    contextUsage: { tokens: input, contextWindow: 100_000, percent: 0 }
+  }
+}
+
 test('PiAcpSession: emits agent_message_chunk for text_delta', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
@@ -705,7 +720,7 @@ test('PiAcpSession: prompt stays open through retry runs until agent_settled', a
 
   proc.emit({ type: 'agent_settled' })
   const reason = await p
-  assert.equal(reason, 'end_turn')
+  assert.deepEqual(reason, { stopReason: 'end_turn' })
 })
 
 test('PiAcpSession: does not re-emit startup info on first prompt after it was already sent', async () => {
@@ -746,7 +761,7 @@ test('PiAcpSession: does not re-emit startup info on first prompt after it was a
   proc.emit({ type: 'agent_settled' })
 
   const reason = await p
-  assert.equal(reason, 'end_turn')
+  assert.deepEqual(reason, { stopReason: 'end_turn' })
 })
 
 test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
@@ -771,12 +786,57 @@ test('PiAcpSession: cancel flips stopReason to cancelled', async () => {
   const reason = await p
 
   assert.equal(proc.abortCount, 1)
-  assert.equal(reason, 'cancelled')
+  assert.deepEqual(reason, { stopReason: 'cancelled' })
 })
 
-test('PiAcpSession: queues concurrent prompt and starts it after agent_settled', async () => {
+test('PiAcpSession: cancellation during usage finalization wins over end_turn', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
+  let statsCalls = 0
+  let resolveFinalStats: ((value: unknown) => void) | undefined
+  proc.getSessionStats = async () => {
+    statsCalls += 1
+    if (statsCalls === 1) return usageStats(0, 0, 0)
+    return new Promise(resolve => {
+      resolveFinalStats = resolve
+    })
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  await new Promise(resolve => setTimeout(resolve, 0))
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  await session.cancel()
+  resolveFinalStats?.(usageStats(2, 1, 0.01))
+
+  assert.deepEqual(await prompt, {
+    stopReason: 'cancelled',
+    usage: {
+      inputTokens: 2,
+      outputTokens: 1,
+      totalTokens: 3,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0
+    }
+  })
+})
+
+test('PiAcpSession: queues concurrent prompt and attributes usage from each actual start', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = [usageStats(0, 0, 0), usageStats(10, 2, 0.1), usageStats(10, 2, 0.1), usageStats(15, 3, 0.15)]
 
   const session = new PiAcpSession({
     sessionId: 's1',
@@ -790,6 +850,7 @@ test('PiAcpSession: queues concurrent prompt and starts it after agent_settled',
   const first = session.prompt('one')
   const second = session.prompt('two')
 
+  await new Promise(r => setTimeout(r, 0))
   assert.equal(proc.prompts.length, 1)
   assert.equal(proc.prompts[0]!.message, 'one')
 
@@ -799,8 +860,18 @@ test('PiAcpSession: queues concurrent prompt and starts it after agent_settled',
   proc.emit({ type: 'agent_settled' })
 
   const r1 = await first
-  assert.equal(r1, 'end_turn')
+  assert.deepEqual(r1, {
+    stopReason: 'end_turn',
+    usage: {
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0
+    }
+  })
 
+  await new Promise(r => setTimeout(r, 0))
   assert.equal(proc.prompts.length, 2)
   assert.equal(proc.prompts[1]!.message, 'two')
 
@@ -810,12 +881,29 @@ test('PiAcpSession: queues concurrent prompt and starts it after agent_settled',
   proc.emit({ type: 'agent_settled' })
 
   const r2 = await second
-  assert.equal(r2, 'end_turn')
+  assert.deepEqual(r2, {
+    stopReason: 'end_turn',
+    usage: {
+      inputTokens: 5,
+      outputTokens: 1,
+      totalTokens: 6,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0
+    }
+  })
+
+  assert.deepEqual(
+    conn.updates
+      .filter(update => update.update.sessionUpdate === 'usage_update')
+      .map(update => (update.update as { cost?: { amount: number } }).cost?.amount),
+    [0, 0.1, 0.1, 0.15]
+  )
 })
 
-test('PiAcpSession: cancel clears queued prompts', async () => {
+test('PiAcpSession: cancel clears queued prompts without attributing active usage to them', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()
+  proc.sessionStats = [usageStats(20, 4, 0.2), usageStats(23, 5, 0.23)]
 
   const session = new PiAcpSession({
     sessionId: 's1',
@@ -829,6 +917,7 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   const first = session.prompt('one')
   const second = session.prompt('two')
 
+  await new Promise(r => setTimeout(r, 0))
   assert.equal(proc.prompts.length, 1)
 
   await session.cancel()
@@ -840,8 +929,17 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   const r1 = await first
   const r2 = await second
 
-  assert.equal(r1, 'cancelled')
-  assert.equal(r2, 'cancelled')
+  assert.deepEqual(r1, {
+    stopReason: 'cancelled',
+    usage: {
+      inputTokens: 3,
+      outputTokens: 1,
+      totalTokens: 4,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0
+    }
+  })
+  assert.deepEqual(r2, { stopReason: 'cancelled' })
 })
 
 test('PiAcpSession: expands /command before sending to pi', async () => {
@@ -865,6 +963,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   })
 
   const p = session.prompt('/hello world')
+  await new Promise(r => setTimeout(r, 0))
   assert.equal(proc.prompts.length, 1)
   assert.equal(proc.prompts[0]!.message, 'Say hello to world')
 
@@ -874,7 +973,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   proc.emit({ type: 'agent_settled' })
 
   const reason = await p
-  assert.equal(reason, 'end_turn')
+  assert.deepEqual(reason, { stopReason: 'end_turn' })
 })
 
 test('PiAcpSession: tags extension notify chunks with severity in _meta', async () => {

--- a/test/component/session-queue-cancel.test.ts
+++ b/test/component/session-queue-cancel.test.ts
@@ -19,6 +19,7 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   const first = session.prompt('one')
   const second = session.prompt('two')
   const third = session.prompt('three')
+  await new Promise(resolve => setTimeout(resolve, 0))
 
   // first started, second+third queued
   assert.equal(proc.prompts.length, 1)
@@ -28,15 +29,15 @@ test('PiAcpSession: cancel clears queued prompts', async () => {
   assert.equal(proc.abortCount, 1)
 
   // queued prompts should resolve as cancelled
-  assert.equal(await second, 'cancelled')
-  assert.equal(await third, 'cancelled')
+  assert.deepEqual(await second, { stopReason: 'cancelled' })
+  assert.deepEqual(await third, { stopReason: 'cancelled' })
 
   // finish first prompt as cancelled after abort
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
   proc.emit({ type: 'agent_end' })
   proc.emit({ type: 'agent_settled' })
-  assert.equal(await first, 'cancelled')
+  assert.deepEqual(await first, { stopReason: 'cancelled' })
 
   // queue should have been cleared, so no further prompt started
   assert.equal(proc.prompts.length, 1)

--- a/test/component/session-slash-commands.test.ts
+++ b/test/component/session-slash-commands.test.ts
@@ -24,6 +24,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   })
 
   const p = session.prompt('/hello world')
+  await new Promise(resolve => setTimeout(resolve, 0))
 
   proc.emit({ type: 'agent_start' })
   proc.emit({ type: 'turn_end' })
@@ -31,7 +32,7 @@ test('PiAcpSession: expands /command before sending to pi', async () => {
   proc.emit({ type: 'agent_settled' })
   const reason = await p
 
-  assert.equal(reason, 'end_turn')
+  assert.deepEqual(reason, { stopReason: 'end_turn' })
   assert.equal(proc.prompts.length, 1)
   assert.equal(proc.prompts[0]!.message, 'Expanded world')
 })

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -29,6 +29,8 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   abortCount = 0
+  getSessionStatsCount = 0
+  sessionStats: unknown[] = []
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
     this.handlers.push(handler)
@@ -55,6 +57,14 @@ export class FakePiRpcProcess {
 
   async getState(): Promise<any> {
     return {}
+  }
+
+  async getSessionStats(): Promise<unknown> {
+    this.getSessionStatsCount += 1
+    if (this.sessionStats.length === 0) throw new Error('getSessionStats unavailable')
+    const value = this.sessionStats.shift()
+    if (value instanceof Error) throw value
+    return value
   }
 
   async getAvailableModels(): Promise<any> {

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -36,7 +36,7 @@ test('PiAcpAgent: prompt auto-restores a missing session from SessionStore', asy
     proc: params.proc,
     async prompt(message: string, images: unknown[]) {
       promptCalls.push({ message, images })
-      return 'end_turn'
+      return { stopReason: 'end_turn' }
     },
     async cancel() {},
     wasCancelRequested() {

--- a/test/unit/settlement-entry.test.ts
+++ b/test/unit/settlement-entry.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpSession } from '../../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from '../helpers/fakes.js'
+
+function makeSession() {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+  return { conn, proc, session }
+}
+
+const payload = {
+  version: 1,
+  settlements: [
+    { id: 'run-1', label: 'worker', model: 'openai/model', status: 'completed', usage: { costKind: 'api' } }
+  ]
+}
+
+async function finish(proc: FakePiRpcProcess) {
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
+}
+
+test('settlement entry during a turn is attached verbatim under response metadata', async () => {
+  const { proc, session } = makeSession()
+  const prompt = session.prompt('hello')
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  proc.emit({ type: 'entry_appended', entry: { customType: 'lean-subagent-settlements', data: payload } })
+  await finish(proc)
+
+  assert.deepEqual(await prompt, {
+    stopReason: 'end_turn',
+    _meta: { helix: { leanSubagentSettlements: payload } }
+  })
+})
+
+test('settlement entries with a version other than one are ignored', async () => {
+  const { proc, session } = makeSession()
+  const prompt = session.prompt('hello')
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  proc.emit({
+    type: 'entry_appended',
+    entry: { customType: 'lean-subagent-settlements', data: { ...payload, version: 2 } }
+  })
+  await finish(proc)
+
+  assert.deepEqual(await prompt, { stopReason: 'end_turn' })
+})
+
+test('settlement entries outside a turn do not leak into the next turn', async () => {
+  const { proc, session } = makeSession()
+  proc.emit({ type: 'entry_appended', entry: { customType: 'lean-subagent-settlements', data: payload } })
+
+  const prompt = session.prompt('hello')
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await finish(proc)
+
+  assert.deepEqual(await prompt, { stopReason: 'end_turn' })
+})
+
+test('a failed turn clears its buffered settlement', async () => {
+  const { proc, session } = makeSession()
+  const failed = session.prompt('fail')
+  await new Promise(resolve => setTimeout(resolve, 0))
+  proc.emit({ type: 'entry_appended', entry: { customType: 'lean-subagent-settlements', data: payload } })
+  proc.emit({ type: 'auto_retry_end', success: false, attempt: 1 })
+  proc.emit({ type: 'agent_settled' })
+
+  await assert.rejects(failed)
+
+  const next = session.prompt('next')
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await finish(proc)
+  assert.deepEqual(await next, { stopReason: 'end_turn' })
+})
+
+test('other custom entry types retain fall-through behavior', async () => {
+  const { proc, session } = makeSession()
+  const prompt = session.prompt('hello')
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  proc.emit({ type: 'entry_appended', entry: { customType: 'other-entry', data: payload } })
+  await finish(proc)
+
+  assert.deepEqual(await prompt, { stopReason: 'end_turn' })
+})

--- a/test/unit/usage.test.ts
+++ b/test/unit/usage.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { isNonDecreasingUsage, parsePiUsageSnapshot, promptUsageDelta, usageUpdate } from '../../src/acp/usage.js'
+
+function stats(input: number, output: number, cacheRead: number, cacheWrite: number, cost = 0) {
+  return {
+    sessionId: 'session-1',
+    tokens: {
+      input,
+      output,
+      cacheRead,
+      cacheWrite,
+      total: input + output + cacheRead + cacheWrite
+    },
+    cost,
+    contextUsage: { tokens: input + cacheRead + cacheWrite, contextWindow: 200_000, percent: 1 }
+  }
+}
+
+test('usage: computes fresh and resumed per-prompt cumulative deltas', () => {
+  const freshBefore = parsePiUsageSnapshot(stats(0, 0, 0, 0))!
+  const freshAfter = parsePiUsageSnapshot(stats(20, 5, 0, 0, 0.01))!
+  assert.deepEqual(promptUsageDelta(freshBefore, freshAfter), {
+    inputTokens: 20,
+    outputTokens: 5,
+    totalTokens: 25,
+    cachedReadTokens: 0,
+    cachedWriteTokens: 0
+  })
+
+  const resumedBefore = parsePiUsageSnapshot(stats(1_000, 100, 500, 20, 0.5))!
+  const resumedAfter = parsePiUsageSnapshot(stats(1_030, 112, 700, 25, 0.6))!
+  assert.deepEqual(promptUsageDelta(resumedBefore, resumedAfter), {
+    inputTokens: 30,
+    outputTokens: 12,
+    totalTokens: 247,
+    cachedReadTokens: 200,
+    cachedWriteTokens: 5
+  })
+})
+
+test('usage: cache deltas are omitted unless both cumulative snapshots provide them', () => {
+  const before = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 10, output: 2, total: 12 },
+    cost: 0
+  })!
+  const after = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 15, output: 4, total: 22, cacheRead: 3 },
+    cost: 0
+  })!
+
+  assert.deepEqual(promptUsageDelta(before, after), {
+    inputTokens: 5,
+    outputTokens: 2,
+    totalTokens: 10
+  })
+})
+
+test('usage: rejects malformed and decreasing cumulative stats', () => {
+  for (const malformed of [
+    null,
+    {},
+    { sessionId: 'session-1', tokens: { input: 1, output: 2 }, cost: 0 },
+    { sessionId: 'session-1', tokens: { input: -1, output: 2, total: 1 }, cost: 0 },
+    { sessionId: 'session-1', tokens: { input: 1, output: Number.NaN, total: 1 }, cost: 0 },
+    {
+      sessionId: 'session-1',
+      tokens: { input: 1, output: 2, total: 3, cacheRead: Number.POSITIVE_INFINITY },
+      cost: 0
+    },
+    { sessionId: 'session-1', tokens: { input: 1, output: 2, total: 3 }, cost: -1 },
+    {
+      sessionId: 'session-1',
+      tokens: { input: 1, output: 2, total: 99, cacheRead: 0, cacheWrite: 0 },
+      cost: 0
+    }
+  ]) {
+    assert.equal(parsePiUsageSnapshot(malformed), null)
+  }
+
+  const before = parsePiUsageSnapshot(stats(10, 5, 2, 1, 0.2))!
+  const after = parsePiUsageSnapshot(stats(9, 6, 2, 1, 0.3))!
+  assert.equal(isNonDecreasingUsage(before, after), false)
+  assert.equal(promptUsageDelta(before, after), null)
+
+  const differentSession = { ...parsePiUsageSnapshot(stats(11, 6, 2, 1, 0.3))!, sessionId: 'session-2' }
+  assert.equal(promptUsageDelta(before, differentSession), null)
+})
+
+test('usage: maps context occupancy and cumulative USD without substituting null tokens', () => {
+  const available = parsePiUsageSnapshot(stats(10, 2, 4, 1, 0.25))!
+  assert.deepEqual(usageUpdate(available), {
+    used: 15,
+    size: 200_000,
+    cost: { amount: 0.25, currency: 'USD' }
+  })
+
+  const unavailable = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 10, output: 2, total: 12 },
+    cost: 0.25,
+    contextUsage: { tokens: null, contextWindow: 200_000, percent: null }
+  })!
+  assert.equal(usageUpdate(unavailable), null)
+
+  const costUnavailable = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 10, output: 2, total: 12 },
+    contextUsage: { tokens: 10, contextWindow: 200_000 }
+  })!
+  assert.deepEqual(usageUpdate(costUnavailable), { used: 10, size: 200_000 })
+})
+
+test('usage: malformed context does not suppress valid token accounting', () => {
+  const before = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 1, output: 2, total: 3 },
+    contextUsage: { tokens: null, contextWindow: 100 }
+  })!
+  const after = parsePiUsageSnapshot({
+    sessionId: 'session-1',
+    tokens: { input: 4, output: 3, total: 7 },
+    contextUsage: { tokens: 'unknown', contextWindow: 100 }
+  })!
+
+  assert.deepEqual(promptUsageDelta(before, after), {
+    inputTokens: 3,
+    outputTokens: 1,
+    totalTokens: 4
+  })
+  assert.equal(usageUpdate(after), null)
+})


### PR DESCRIPTION
Forwards `lean-subagent-settlements` (v1) custom session entries — emitted by Helix's lean-subagents extension at parent-stop finalization — as `_meta.helix.leanSubagentSettlements` on the turn's PromptResponse, so the ACP client gets per-child terminal status and usage/cost provenance for join-on-final children.

- `entry_appended` branch in the Pi event switch: validates customType + `version === 1`, buffers on the in-flight turn (last write wins); invalid payloads debug-logged and ignored
- buffer lives on the PendingTurn, so a failed/cancelled turn cannot leak settlements into a later response
- `_meta` forwarded through the ACP PromptResponse (legal per ACP 0.26 `_meta` extensibility)
- tests: forwarding, invalid version, no active turn, failed-turn cleanup, unrelated custom types

107 tests pass, typecheck + lint clean. Consumed by FunkePublishing/spark-agents#1296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)