### PR TITLE
feat: add _session/steering extension method for mid-turn message injection

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -21,7 +21,8 @@ import {
   type SetSessionModeResponse,
   type StopReason,
   type DeleteSessionRequest,
-  type DeleteSessionResponse
+  type DeleteSessionResponse,
+  type ContentBlock
 } from '@agentclientprotocol/sdk'
 import { getAuthMethods } from './auth.js'
 import { SessionManager, type PiAcpSession } from './session.js'
@@ -234,6 +235,41 @@ export class PiAcpAgent implements ACPAgent {
     }
   }
 
+  // ACP extension method (SDK routes unknown `_session/*` requests here).
+  // Implements the `_session/steering` contract (same method name as
+  // @agentclientprotocol/claude-agent-acp): inject a message into the RUNNING
+  // turn via pi's native `steer` RPC (delivered before the next LLM call) and
+  // answer `injected`; when idle, either report `promptRequired` (client opted
+  // in via _meta and will redeliver the text as a trackable `session/prompt`)
+  // or start a new turn fire-and-forget. NOTE: unrelated to pi's `/steering`
+  // slash command (queue delivery mode).
+  async extMethod(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    if (method === '_session/steering') {
+      const sessionId = params.sessionId
+      if (typeof sessionId !== 'string' || !sessionId) {
+        throw RequestError.invalidParams('_session/steering requires a sessionId')
+      }
+
+      const session = await this.restoreSession(sessionId)
+      const prompt = (Array.isArray(params.prompt) ? params.prompt : []) as ContentBlock[]
+      const { message, images } = promptToPiMessage(prompt)
+
+      if (!session.hasPendingTurn) {
+        if ((params as any)?._meta?.steering?.idleBehavior === 'promptRequired') {
+          return { outcome: 'promptRequired', reason: 'noRunningTurn' }
+        }
+        // Fire-and-forget: the steering response must not block on a whole turn.
+        this.prompt({ sessionId, prompt }).catch(() => {})
+        return { outcome: 'startedNewTurn' }
+      }
+
+      await session.proc.steer(message, images)
+      return { outcome: 'injected' }
+    }
+
+    throw RequestError.methodNotFound(method)
+  }
+
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {
     // We currently only support ACP protocol version 1.
     const supportedVersion = 1
@@ -241,6 +277,9 @@ export class PiAcpAgent implements ACPAgent {
 
     return {
       protocolVersion: requested === supportedVersion ? requested : supportedVersion,
+      // Advertise the `_session/steering` extension method (additive `_meta`:
+      // merge with any other `_meta` keys, never replace them).
+      _meta: { steering: { supported: true } },
       agentInfo: {
         name: pkg.name ?? 'pi-acp',
         title: 'pi ACP adapter',

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -255,7 +255,8 @@ export class PiAcpAgent implements ACPAgent {
       const { message, images } = promptToPiMessage(prompt)
 
       if (!session.hasPendingTurn) {
-        if ((params as any)?._meta?.steering?.idleBehavior === 'promptRequired') {
+        const meta = params._meta as { steering?: { idleBehavior?: string } } | undefined
+        if (meta?.steering?.idleBehavior === 'promptRequired') {
           return { outcome: 'promptRequired', reason: 'noRunningTurn' }
         }
         // Fire-and-forget: the steering response must not block on a whole turn.
@@ -263,7 +264,11 @@ export class PiAcpAgent implements ACPAgent {
         return { outcome: 'startedNewTurn' }
       }
 
-      await session.proc.steer(message, images)
+      try {
+        await session.proc.steer(message, images)
+      } catch (e) {
+        throw RequestError.internalError({}, String((e as Error)?.message ?? e))
+      }
       return { outcome: 'injected' }
     }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -273,6 +273,12 @@ export class PiAcpSession {
 
   // Current in-flight turn (if any). Additional prompts are queued.
   private pendingTurn: PendingTurn | null = null
+
+  /** Whether a turn is currently in progress (read by the `_session/steering` extension method). */
+  get hasPendingTurn(): boolean {
+    return this.pendingTurn !== null
+  }
+
   private readonly turnQueue: QueuedTurn[] = []
   // Track tool call statuses and ensure they are monotonic (pending -> in_progress -> completed).
   // Some pi events can arrive out of order (e.g. late toolcall_* deltas after execution starts),

--- a/src/pi-rpc/process.ts
+++ b/src/pi-rpc/process.ts
@@ -29,6 +29,7 @@ function stripAnsi(s: string): string {
 
 type PiRpcCommand =
   | { type: 'prompt'; id?: string; message: string; images?: unknown[] }
+  | { type: 'steer'; id?: string; message: string; images?: unknown[] }
   | { type: 'abort'; id?: string }
   | { type: 'get_state'; id?: string }
   // Model
@@ -238,6 +239,16 @@ export class PiRpcProcess {
   async abort(): Promise<void> {
     const res = await this.request({ type: 'abort' })
     if (!res.success) throw new Error(`pi abort failed: ${res.error ?? JSON.stringify(res.data)}`)
+  }
+
+  /**
+   * Steer a running turn: deliver `message` (and optional `images`) to the
+   * agent mid-turn, before its next LLM call. No-op if no turn is running;
+   * callers decide idle semantics (see the `_session/steering` ext method).
+   */
+  async steer(message: string, images: unknown[] = []): Promise<void> {
+    const res = await this.request({ type: 'steer', message, images })
+    if (!res.success) throw new Error(`pi steer failed: ${res.error ?? JSON.stringify(res.data)}`)
   }
 
   async getState(): Promise<unknown> {

--- a/test/agent-steering.test.ts
+++ b/test/agent-steering.test.ts
@@ -1,0 +1,122 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { PiAcpAgent } from '../src/acp/agent.js'
+import { PiAcpSession } from '../src/acp/session.js'
+import { FakeAgentSideConnection, FakePiRpcProcess, asAgentConn } from './helpers/fakes.js'
+
+/**
+ * Contract for the `_session/steering` ACP extension method (same method name
+ * as @agentclientprotocol/claude-agent-acp). NOTE: this is unrelated to pi's
+ * `/steering` slash command, which toggles queue delivery mode.
+ */
+function makeAgentWithSession(sessionId = 's-steer') {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const session = new PiAcpSession({
+    sessionId,
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const agent = new PiAcpAgent(asAgentConn(conn))
+  // Inject the session so restoreSession() finds it without spawning pi.
+  ;(agent as any).sessions = {
+    maybeGet: (id: string) => (id === sessionId ? session : null)
+  }
+
+  return { agent, proc, session }
+}
+
+test('initialize: advertises _meta.steering.supported = true', async () => {
+  const agent = new PiAcpAgent(asAgentConn(new FakeAgentSideConnection()))
+  const res = await agent.initialize({ protocolVersion: 1 } as any)
+
+  assert.equal((res as any)._meta?.steering?.supported, true)
+})
+
+test('_session/steering: outcome injected when a turn is running', async () => {
+  const { agent, proc, session } = makeAgentWithSession()
+
+  // Start a turn; the fake proc never emits agent_settled, so it stays pending.
+  void session.prompt('first turn')
+  await new Promise(r => setTimeout(r, 0))
+
+  const res = await agent.extMethod('_session/steering', {
+    sessionId: 's-steer',
+    prompt: [{ type: 'text', text: 'vira a plan b' }]
+  })
+
+  assert.deepEqual(res, { outcome: 'injected' })
+  assert.equal(proc.steers.length, 1)
+  assert.equal(proc.steers[0]!.message, 'vira a plan b')
+  assert.deepEqual(proc.steers[0]!.images, [])
+})
+
+test('_session/steering: outcome injected passes images through untouched', async () => {
+  const { agent, proc, session } = makeAgentWithSession()
+
+  void session.prompt('turn with images')
+  await new Promise(r => setTimeout(r, 0))
+
+  const images = [{ type: 'image', mimeType: 'image/png', data: 'aGk=' }]
+  await agent.extMethod('_session/steering', {
+    sessionId: 's-steer',
+    prompt: [{ type: 'text', text: 'mirá esto' }, ...images]
+  })
+
+  assert.equal(proc.steers.length, 1)
+  assert.equal(proc.steers[0]!.message, 'mirá esto')
+  assert.deepEqual(proc.steers[0]!.images, images)
+})
+
+test('_session/steering: outcome promptRequired when idle and client opted in', async () => {
+  const { agent, proc } = makeAgentWithSession()
+
+  const res = await agent.extMethod('_session/steering', {
+    sessionId: 's-steer',
+    prompt: [{ type: 'text', text: 'no hay turno' }],
+    _meta: { steering: { idleBehavior: 'promptRequired' } }
+  })
+
+  assert.deepEqual(res, { outcome: 'promptRequired', reason: 'noRunningTurn' })
+  assert.equal(proc.steers.length, 0)
+  assert.equal(proc.prompts.length, 0) // no turn started
+})
+
+test('_session/steering: outcome startedNewTurn starts a detached prompt when idle', async () => {
+  const { agent, proc } = makeAgentWithSession()
+
+  const res = await agent.extMethod('_session/steering', {
+    sessionId: 's-steer',
+    prompt: [{ type: 'text', text: 'empezá de una' }]
+  })
+
+  // Response must not wait for the turn to finish.
+  assert.deepEqual(res, { outcome: 'startedNewTurn' })
+
+  // Fire-and-forget: give the detached prompt a tick to reach the fake proc.
+  await new Promise(r => setTimeout(r, 0))
+  assert.equal(proc.prompts.length, 1)
+  assert.equal(proc.prompts[0]!.message, 'empezá de una')
+})
+
+test('_session/steering: unknown session returns an ACP error', async () => {
+  const { agent } = makeAgentWithSession()
+
+  await assert.rejects(
+    () => agent.extMethod('_session/steering', { sessionId: 'nope', prompt: [] }),
+    (e: any) => e?.code === -32602 // invalidParams, same as session/prompt on unknown ids
+  )
+})
+
+test('extMethod: unknown method returns methodNotFound', async () => {
+  const { agent } = makeAgentWithSession()
+
+  await assert.rejects(
+    () => agent.extMethod('_session/other', {}),
+    (e: any) => e?.code === -32601
+  )
+})

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -28,6 +28,7 @@ export class FakePiRpcProcess {
   // spies
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
+  readonly steers: Array<{ message: string; images: unknown[] }> = []
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -47,6 +48,10 @@ export class FakePiRpcProcess {
 
   async abort(): Promise<void> {
     this.abortCount += 1
+  }
+
+  async steer(message: string, images: unknown[] = []): Promise<void> {
+    this.steers.push({ message, images })
   }
 
   async sendExtensionUiResponse(response: unknown): Promise<void> {


### PR DESCRIPTION
## What

Adds an ACP extension method — `_session/steering`, the same method name used by [`@agentclientprotocol/claude-agent-acp`](https://github.com/zed-industries/claude-agent-acp/blob/main/src/acp-agent.ts) — so clients can inject a message into the **running** turn via pi's native `steer` RPC (delivered before the next LLM call) instead of waiting for the turn boundary.

- `initialize()` now advertises `_meta.steering.supported = true` (additive `_meta`; other keys merge, never replaced).
- `PiRpcProcess.steer(message, images)` — sibling of `abort()` — sends the `{ type: 'steer', message, images }` RPC frame with passthrough content.
- `PiAcpAgent.extMethod('_session/steering')` with three outcomes:
  - turn running → `proc.steer(...)` → `{ outcome: 'injected' }`
  - idle + client opt-in (`_meta.steering.idleBehavior === 'promptRequired'`) → `{ outcome: 'promptRequired', reason: 'noRunningTurn' }` (client redelivers as a trackable `session/prompt`)
  - idle without opt-in → fire-and-forget `prompt()` → `{ outcome: 'startedNewTurn' }`
- Unknown ext methods still answer `methodNotFound`; RPC steer failures propagate as standard ACP errors.

Note: this is **unrelated** to pi's `/steering` slash command (queue delivery mode) — that is untouched.

## Tests

`test/agent-steering.test.ts` (no LLM, extends `FakePiRpcProcess` with a steer spy): capability advertisement, `injected` (message + image passthrough), `promptRequired`, `startedNewTurn` (detached), unknown session and unknown method errors. Full suite: **95 passed / 0 failed** (`node --import tsx --test`).