### PR TITLE
Emit ACP context usage updates

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -471,6 +471,7 @@ export class PiAcpAgent implements ACPAgent {
             content: { type: 'text', text }
           }
         })
+        await session.sendUsageUpdate()
 
         return { stopReason: 'end_turn' }
       }
@@ -1073,9 +1074,10 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    // Advertise slash commands after the response so the client knows the session exists.
+    // Advertise session state after the response so the client knows the session exists.
     setTimeout(() => {
       void (async () => {
+        await session.sendUsageUpdate()
         try {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -1138,6 +1140,7 @@ export class PiAcpAgent implements ACPAgent {
     const session = await this.restoreSession(params.sessionId)
     await setSessionModel(session.proc, params.modelId)
     await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    await session.sendUsageUpdate()
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1193,6 +1196,7 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    if (configId === MODEL_CONFIG_ID) await session.sendUsageUpdate()
     return { configOptions }
   }
 }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -295,6 +295,7 @@ export class PiAcpSession {
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
   private lastEmit: Promise<void> = Promise.resolve()
+  private lastUsage: { used: number; size: number } | null = null
 
   constructor(opts: {
     sessionId: string
@@ -415,6 +416,27 @@ export class PiAcpSession {
 
   private async flushEmits(): Promise<void> {
     await this.lastEmit
+  }
+
+  /** Publish pi's current context-window reading when one is available. */
+  async sendUsageUpdate(): Promise<void> {
+    try {
+      const stats = (await this.proc.getSessionStats()) as any
+      const contextUsage = stats?.contextUsage
+      const used = contextUsage?.tokens
+      const size = contextUsage?.contextWindow
+
+      if (Number.isSafeInteger(used) && used >= 0 && Number.isSafeInteger(size) && size > 0) {
+        if (!this.lastUsage || this.lastUsage.used !== used || this.lastUsage.size !== size) {
+          this.lastUsage = { used, size }
+          this.emit({ sessionUpdate: 'usage_update', used, size })
+        }
+      }
+    } catch {
+      // Older pi versions may not expose contextUsage. Usage is optional in ACP.
+    }
+
+    await this.flushEmits()
   }
 
   private emitBashToolCall(params: {
@@ -837,9 +859,9 @@ export class PiAcpSession {
       }
 
       case 'agent_settled': {
-        // Ensure all updates derived from pi events are delivered before we resolve
-        // the ACP `session/prompt` request.
-        void this.flushEmits().finally(() => {
+        // Publish the final context reading and ensure all updates derived from pi
+        // events are delivered before we resolve the ACP `session/prompt` request.
+        void this.sendUsageUpdate().finally(() => {
           const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
           this.pendingTurn?.resolve(reason)
           this.pendingTurn = null

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -62,6 +62,65 @@ test('PiAcpSession: emits agent_thought_chunk for thinking_delta', async () => {
   })
 })
 
+test('PiAcpSession: emits context usage before a settled prompt completes', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: { tokens: 56_549, contextWindow: 272_000, percent: 20.79 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.deepEqual(
+    conn.updates.find(entry => entry.update.sessionUpdate === 'usage_update'),
+    {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 56_549, size: 272_000 }
+    }
+  )
+})
+
+test('PiAcpSession: omits unavailable usage and de-duplicates unchanged readings', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.sessionStats = { contextUsage: { tokens: null, contextWindow: 272_000, percent: null } }
+  await session.sendUsageUpdate()
+  assert.equal(conn.updates.length, 0)
+
+  proc.sessionStats = { contextUsage: { tokens: 1_200, contextWindow: 272_000, percent: 0.44 } }
+  await session.sendUsageUpdate()
+  await session.sendUsageUpdate()
+
+  assert.deepEqual(conn.updates, [
+    {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 1_200, size: 272_000 }
+    }
+  ])
+})
+
 test('PiAcpSession: emits tool_call + tool_call_update + completes', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -28,6 +28,7 @@ export class FakePiRpcProcess {
   // spies
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
+  sessionStats: unknown = {}
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -63,6 +64,10 @@ export class FakePiRpcProcess {
 
   async getMessages(): Promise<any> {
     return { messages: [] }
+  }
+
+  async getSessionStats(): Promise<unknown> {
+    return this.sessionStats
   }
 }
 

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -121,7 +121,8 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
         setModelCalls.push({ provider, modelId })
         state.model = { provider, id: modelId }
       }
-    }
+    },
+    async sendUsageUpdate() {}
   }
 
   const agent = new PiAcpAgent(asAgentConn(conn), {} as any)

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -129,7 +129,8 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
   const sessions = new FakeSessions((sessionId, params) => ({
     sessionId,
     cwd: params.cwd,
-    proc: params.proc
+    proc: params.proc,
+    async sendUsageUpdate() {}
   }))
 
   const originalSpawn = PiRpcProcess.spawn


### PR DESCRIPTION
## Summary
- read Pi context usage from `get_session_stats`
- emit ACP `usage_update` after settled turns, session loads, compaction, and model changes
- omit unavailable readings and de-duplicate unchanged values

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (97 tests)
- `npm run build`
- live `session/load` emitted `{"sessionUpdate":"usage_update","used":89165,"size":272000}`