### PR TITLE
Support Pi extension commands over ACP

### DIFF
--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -401,7 +401,7 @@ export class PiAcpAgent implements ACPAgent {
           const pi = (await session.proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
             enableSkillCommands,
-            includeExtensionCommands: false
+            includeExtensionCommands: true
           })
 
           await this.conn.sessionUpdate({
@@ -883,6 +883,32 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
+    // Extension commands are Pi command handlers, not model prompts. RPC resolves
+    // after the handler, including child agents and extension UI requests, finishes.
+    // They cannot use the normal agent_settled lifecycle because command-only handlers
+    // do not start a parent agent loop.
+    if (images.length === 0 && message.trimStart().startsWith('/')) {
+      const trimmed = message.trim()
+      const space = trimmed.indexOf(' ')
+      const commandName = space === -1 ? trimmed.slice(1) : trimmed.slice(1, space)
+      try {
+        const piCommands = (await session.proc.getCommands()) as any
+        const raw = toAvailableCommandsFromPiGetCommands(piCommands, {
+          enableSkillCommands: true,
+          includeExtensionCommands: true
+        }).raw
+        const isExtensionCommand = raw.some(
+          command => command.source === 'extension' && command.name === commandName
+        )
+        if (isExtensionCommand) {
+          const result = await session.runExtensionCommand(message)
+          return { stopReason: result === 'cancelled' ? 'cancelled' : 'end_turn' }
+        }
+      } catch {
+        // Discovery is best-effort. Fall through for older Pi RPC implementations.
+      }
+    }
+
     const result = await session.prompt(message, images)
 
     // ACP StopReason does not include "error"; if pi fails we map to end_turn for now,
@@ -1082,7 +1108,7 @@ export class PiAcpAgent implements ACPAgent {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
             enableSkillCommands,
-            includeExtensionCommands: false
+            includeExtensionCommands: true
           })
 
           await this.conn.sessionUpdate({

--- a/src/acp/agent.ts
+++ b/src/acp/agent.ts
@@ -471,6 +471,7 @@ export class PiAcpAgent implements ACPAgent {
             content: { type: 'text', text }
           }
         })
+        await session.sendUsageUpdate()
 
         return { stopReason: 'end_turn' }
       }
@@ -1073,9 +1074,10 @@ export class PiAcpAgent implements ACPAgent {
       }
     }
 
-    // Advertise slash commands after the response so the client knows the session exists.
+    // Advertise session state after the response so the client knows the session exists.
     setTimeout(() => {
       void (async () => {
+        await session.sendUsageUpdate()
         try {
           const pi = (await proc.getCommands()) as any
           const { commands } = toAvailableCommandsFromPiGetCommands(pi, {
@@ -1138,6 +1140,7 @@ export class PiAcpAgent implements ACPAgent {
     const session = await this.restoreSession(params.sessionId)
     await setSessionModel(session.proc, params.modelId)
     await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    await session.sendUsageUpdate()
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
@@ -1193,6 +1196,7 @@ export class PiAcpAgent implements ACPAgent {
     }
 
     const configOptions = await emitConfigOptionsUpdate(this.conn, session.sessionId, session.proc)
+    if (configId === MODEL_CONFIG_ID) await session.sendUsageUpdate()
     return { configOptions }
   }
 }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -59,6 +59,78 @@ const CONFIRM_PERMISSION_OPTIONS: PermissionOption[] = [
 const EXTENSION_UI_RAW_INPUT_KEYS = ['title', 'message', 'options', 'placeholder', 'prefill'] as const
 const CHOICE_OPTION_PREFIX = 'choice-'
 
+function compactFusionAgent(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null
+  const source = value as Record<string, unknown>
+  return Object.fromEntries(
+    [
+      'role',
+      'model',
+      'slotId',
+      'slotName',
+      'color',
+      'primary',
+      'architect',
+      'thinking',
+      'status',
+      'ms',
+      'tokensIn',
+      'tokensOut',
+      'costUsd',
+      'toolCalls',
+      'error'
+    ]
+      .filter(key => key in source)
+      .map(key => [key, source[key]])
+  )
+}
+
+function compactFusionDetails(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null
+  const source = value as Record<string, unknown>
+  const compact = Object.fromEntries(
+    [
+      'kind',
+      'command',
+      'title',
+      'ok',
+      'round',
+      'maxRounds',
+      'artifactsDir',
+      'totalMs',
+      'totalCostUsd',
+      'gateExitCode',
+      'error'
+    ]
+      .filter(key => key in source)
+      .map(key => [key, source[key]])
+  )
+  if (Array.isArray(source.models)) {
+    compact.models = source.models.filter(model => typeof model === 'string')
+  }
+  for (const key of ['roles', 'sources'] as const) {
+    if (Array.isArray(source[key])) {
+      compact[key] = source[key].map(compactFusionAgent).filter(item => item !== null)
+    }
+  }
+  // Preserve per-model provenance without repeating unbounded report bodies.
+  // The visible ACP content remains authoritative; these bounded answers let
+  // native clients restore the upstream panel/round structure.
+  if (Array.isArray(source.answers) && source.answers.length > 0) {
+    const perAnswer = Math.max(2_000, Math.min(60_000, Math.floor(240_000 / source.answers.length)))
+    compact.answers = source.answers.flatMap(value => {
+      const identity = compactFusionAgent(value)
+      if (!identity || !value || typeof value !== 'object') return []
+      const text = (value as Record<string, unknown>).text
+      if (typeof text !== 'string') return [{ ...identity, text: '' }]
+      return [{ ...identity, text: text.length <= perAnswer ? text : `${text.slice(0, perAnswer)}\n… [answer truncated in transport; complete report remains in run artifacts]` }]
+    })
+  }
+  const agent = compactFusionAgent(source.agent)
+  if (agent) compact.agent = agent
+  return compact
+}
+
 function findUniqueLineNumber(text: string, needle: string): number | undefined {
   if (!needle) return undefined
 
@@ -373,6 +445,40 @@ export class PiAcpSession {
     return turnPromise
   }
 
+  /** Execute a Pi extension command through RPC without waiting for agent_settled.
+   * Extension handlers may run child agents and extension UI requests, but the parent
+   * Pi session does not start an agent loop for the command itself. The RPC response is
+   * therefore the authoritative completion boundary.
+   */
+  async runExtensionCommand(message: string): Promise<StopReason> {
+    if (this.pendingTurn) {
+      throw RequestError.invalidParams('Cannot start an extension command while an agent turn is running')
+    }
+
+    this.cancelRequested = false
+    this.emit({
+      sessionUpdate: 'session_info_update',
+      _meta: { piAcp: { queueDepth: 0, running: true, extensionCommand: message.split(/\s+/, 1)[0] } }
+    })
+
+    try {
+      await this.proc.prompt(message, [])
+      await this.flushEmits()
+      await this.sendUsageUpdate()
+      return this.cancelRequested ? 'cancelled' : 'end_turn'
+    } catch (error) {
+      const authError = maybeAuthRequiredError(error)
+      if (authError) throw authError
+      return this.cancelRequested ? 'cancelled' : 'error'
+    } finally {
+      this.emit({
+        sessionUpdate: 'session_info_update',
+        _meta: { piAcp: { queueDepth: 0, running: false } }
+      })
+      await this.flushEmits()
+    }
+  }
+
   async cancel(): Promise<void> {
     // Cancel current and clear any queued prompts.
     this.cancelRequested = true
@@ -629,6 +735,28 @@ export class PiAcpSession {
         }
 
         // Ignore other delta/event types for now.
+        break
+      }
+
+      case 'message_end': {
+        const message = (ev as any).message
+        if (message?.role !== 'custom' || message?.display === false) break
+        const text = typeof message.content === 'string' ? message.content : ''
+        const customType = typeof message.customType === 'string' ? message.customType : null
+        const compactDetails = customType === 'fusion-harness' ? compactFusionDetails(message.details) : null
+        // Empty Fusion banners still carry the model roster and stage change.
+        // Other empty custom messages remain invisible.
+        if (!text && !compactDetails) break
+        this.emit({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text },
+          _meta: {
+            piAcp: {
+              customType,
+              details: compactDetails
+            }
+          }
+        } as SessionUpdate)
         break
       }
 
@@ -920,11 +1048,26 @@ export class PiAcpSession {
     }
 
     if (method === 'notify') {
+      const rawMessage = stringProp(ev, 'message') ?? 'Pi notification'
+      const isFusion = rawMessage.startsWith('fusion-harness:')
+      let message = rawMessage
+      if (isFusion && rawMessage.includes('session-only, YAML unchanged')) {
+        message = 'Model stack updated for this conversation.'
+      } else if (isFusion && rawMessage.includes('not available to clean-room Harness agents')) {
+        message = 'That model cannot run inside Harness. Choose another model.'
+      } else if (isFusion && rawMessage.includes('could not switch Main host model')) {
+        message = 'Main could not switch to that model. Choose another model.'
+      }
       this.emit({
         sessionUpdate: 'agent_message_chunk',
-        content: { type: 'text', text: stringProp(ev, 'message') ?? 'Pi notification' } satisfies ContentBlock,
-        _meta: { piAcp: { notify: { level: stringProp(ev, 'notifyType') ?? 'info' } } }
-      })
+        content: { type: 'text', text: message } satisfies ContentBlock,
+        _meta: {
+          piAcp: {
+            notify: { level: stringProp(ev, 'notifyType') ?? 'info' },
+            ...(isFusion ? { customType: 'fusion-harness', details: { kind: 'notice', command: 'fh-model', ok: !rawMessage.includes('error') } } : {})
+          }
+        }
+      } as SessionUpdate)
       await this.proc.sendExtensionUiResponse({ id, cancelled: true })
       return
     }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -295,6 +295,7 @@ export class PiAcpSession {
   // Ensure `session/update` notifications are sent in order and can be awaited
   // before completing a `session/prompt` request.
   private lastEmit: Promise<void> = Promise.resolve()
+  private lastUsage: { used: number; size: number } | null = null
 
   constructor(opts: {
     sessionId: string
@@ -415,6 +416,27 @@ export class PiAcpSession {
 
   private async flushEmits(): Promise<void> {
     await this.lastEmit
+  }
+
+  /** Publish pi's current context-window reading when one is available. */
+  async sendUsageUpdate(): Promise<void> {
+    try {
+      const stats = (await this.proc.getSessionStats()) as any
+      const contextUsage = stats?.contextUsage
+      const used = contextUsage?.tokens
+      const size = contextUsage?.contextWindow
+
+      if (Number.isSafeInteger(used) && used >= 0 && Number.isSafeInteger(size) && size > 0) {
+        if (!this.lastUsage || this.lastUsage.used !== used || this.lastUsage.size !== size) {
+          this.lastUsage = { used, size }
+          this.emit({ sessionUpdate: 'usage_update', used, size })
+        }
+      }
+    } catch {
+      // Older pi versions may not expose contextUsage. Usage is optional in ACP.
+    }
+
+    await this.flushEmits()
   }
 
   private emitBashToolCall(params: {
@@ -837,9 +859,9 @@ export class PiAcpSession {
       }
 
       case 'agent_settled': {
-        // Ensure all updates derived from pi events are delivered before we resolve
-        // the ACP `session/prompt` request.
-        void this.flushEmits().finally(() => {
+        // Publish the final context reading and ensure all updates derived from pi
+        // events are delivered before we resolve the ACP `session/prompt` request.
+        void this.sendUsageUpdate().finally(() => {
           const reason: StopReason = this.cancelRequested ? 'cancelled' : 'end_turn'
           this.pendingTurn?.resolve(reason)
           this.pendingTurn = null

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -205,6 +205,105 @@ test('PiAcpSession: emits tool locations from pi path args', async () => {
   assert.deepEqual((conn.updates[0]!.update as any).locations, [{ path: `${process.cwd()}/src/acp/session.ts` }])
 })
 
+test('PiAcpSession: forwards compact Fusion progress including empty banners', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+
+  new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.emit({
+    type: 'message_end',
+    message: {
+      role: 'custom',
+      customType: 'fusion-harness',
+      content: 'Research stage complete',
+      display: true,
+      details: {
+        kind: 'multi',
+        command: 'fh-fusion',
+        ok: true,
+        sources: [{ role: 'ARCHITECT', model: 'anthropic/opus', slotName: 'Opus', status: 'done', toolEvents: [{ name: 'read', argument: 'large' }] }],
+        answers: [{ role: 'ARCHITECT', model: 'anthropic/opus', text: 'very large answer' }]
+      }
+    }
+  } as any)
+  proc.emit({
+    type: 'message_end',
+    message: {
+      role: 'custom',
+      customType: 'fusion-harness',
+      content: '',
+      display: true,
+      details: { kind: 'banner', command: 'fh-fusion', ok: true, roles: [{ role: 'ARCHITECT', model: 'anthropic/opus', slotName: 'Opus' }] }
+    }
+  } as any)
+  proc.emit({
+    type: 'message_end',
+    message: {
+      role: 'custom',
+      customType: 'fusion-harness',
+      content: 'hidden continuation',
+      display: false
+    }
+  } as any)
+
+  await new Promise(r => setTimeout(r, 0))
+
+  assert.equal(conn.updates.length, 2)
+  assert.deepEqual((conn.updates[0]!.update as any)._meta.piAcp.details, {
+    kind: 'multi',
+    command: 'fh-fusion',
+    ok: true,
+    sources: [{ role: 'ARCHITECT', model: 'anthropic/opus', slotName: 'Opus', status: 'done' }],
+    answers: [{ role: 'ARCHITECT', model: 'anthropic/opus', text: 'very large answer' }]
+  })
+  assert.deepEqual(conn.updates[1]!.update, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: '' },
+    _meta: {
+      piAcp: {
+        customType: 'fusion-harness',
+        details: {
+          kind: 'banner',
+          command: 'fh-fusion',
+          ok: true,
+          roles: [{ role: 'ARCHITECT', model: 'anthropic/opus', slotName: 'Opus' }]
+        }
+      }
+    }
+  })
+})
+
+test('PiAcpSession: extension command completes on RPC response without agent_settled', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = { contextUsage: { tokens: 42, contextWindow: 1000 } }
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const reason = await session.runExtensionCommand('/fh-system-prompt')
+
+  assert.equal(reason, 'end_turn')
+  assert.deepEqual(proc.prompts, [{ message: '/fh-system-prompt', attachments: [] }])
+  assert.deepEqual(
+    conn.updates.map(item => item.update.sessionUpdate),
+    ['session_info_update', 'usage_update', 'session_info_update']
+  )
+})
+
 test('PiAcpSession: handles extension select via ACP permission request', async () => {
   const conn = new FakeAgentSideConnection()
   conn.nextPermissionResponse = { outcome: { outcome: 'selected', optionId: 'choice-1' } }

--- a/test/component/session-events.test.ts
+++ b/test/component/session-events.test.ts
@@ -62,6 +62,65 @@ test('PiAcpSession: emits agent_thought_chunk for thinking_delta', async () => {
   })
 })
 
+test('PiAcpSession: emits context usage before a settled prompt completes', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  proc.sessionStats = {
+    contextUsage: { tokens: 56_549, contextWindow: 272_000, percent: 20.79 }
+  }
+
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  const prompt = session.prompt('hello')
+  proc.emit({ type: 'agent_start' })
+  proc.emit({ type: 'agent_end' })
+  proc.emit({ type: 'agent_settled' })
+
+  assert.equal(await prompt, 'end_turn')
+  assert.deepEqual(
+    conn.updates.find(entry => entry.update.sessionUpdate === 'usage_update'),
+    {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 56_549, size: 272_000 }
+    }
+  )
+})
+
+test('PiAcpSession: omits unavailable usage and de-duplicates unchanged readings', async () => {
+  const conn = new FakeAgentSideConnection()
+  const proc = new FakePiRpcProcess()
+  const session = new PiAcpSession({
+    sessionId: 's1',
+    cwd: process.cwd(),
+    mcpServers: [],
+    proc: proc as any,
+    conn: asAgentConn(conn),
+    fileCommands: []
+  })
+
+  proc.sessionStats = { contextUsage: { tokens: null, contextWindow: 272_000, percent: null } }
+  await session.sendUsageUpdate()
+  assert.equal(conn.updates.length, 0)
+
+  proc.sessionStats = { contextUsage: { tokens: 1_200, contextWindow: 272_000, percent: 0.44 } }
+  await session.sendUsageUpdate()
+  await session.sendUsageUpdate()
+
+  assert.deepEqual(conn.updates, [
+    {
+      sessionId: 's1',
+      update: { sessionUpdate: 'usage_update', used: 1_200, size: 272_000 }
+    }
+  ])
+})
+
 test('PiAcpSession: emits tool_call + tool_call_update + completes', async () => {
   const conn = new FakeAgentSideConnection()
   const proc = new FakePiRpcProcess()

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -29,6 +29,7 @@ export class FakePiRpcProcess {
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
   sessionStats: unknown = {}
+  commands: unknown = { commands: [] }
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -68,6 +69,10 @@ export class FakePiRpcProcess {
 
   async getSessionStats(): Promise<unknown> {
     return this.sessionStats
+  }
+
+  async getCommands(): Promise<unknown> {
+    return this.commands
   }
 }
 

--- a/test/helpers/fakes.ts
+++ b/test/helpers/fakes.ts
@@ -28,6 +28,7 @@ export class FakePiRpcProcess {
   // spies
   readonly prompts: Array<{ message: string; attachments: unknown[] }> = []
   readonly extensionUiResponses: unknown[] = []
+  sessionStats: unknown = {}
   abortCount = 0
 
   onEvent(handler: (ev: PiRpcEvent) => void): () => void {
@@ -63,6 +64,10 @@ export class FakePiRpcProcess {
 
   async getMessages(): Promise<any> {
     return { messages: [] }
+  }
+
+  async getSessionStats(): Promise<unknown> {
+    return this.sessionStats
   }
 }
 

--- a/test/unit/session-config-options.test.ts
+++ b/test/unit/session-config-options.test.ts
@@ -121,7 +121,8 @@ test('PiAcpAgent: setSessionConfigOption maps model changes to pi and emits conf
         setModelCalls.push({ provider, modelId })
         state.model = { provider, id: modelId }
       }
-    }
+    },
+    async sendUsageUpdate() {}
   }
 
   const agent = new PiAcpAgent(asAgentConn(conn), {} as any)

--- a/test/unit/session-restore.test.ts
+++ b/test/unit/session-restore.test.ts
@@ -129,7 +129,8 @@ test('PiAcpAgent: setSessionConfigOption auto-restores via pi session discovery 
   const sessions = new FakeSessions((sessionId, params) => ({
     sessionId,
     cwd: params.cwd,
-    proc: params.proc
+    proc: params.proc,
+    async sendUsageUpdate() {}
   }))
 
   const originalSpawn = PiRpcProcess.spawn


### PR DESCRIPTION
Adds end-to-end support for Pi extension commands such as Fusion Harness workflows.

- advertises extension-sourced commands
- dispatches extension commands through Pi RPC
- completes command-only handlers without waiting for `agent_settled`
- forwards visible custom extension messages with metadata
- preserves extension select/confirm UI through ACP permission requests
- adds component coverage

This is stacked on #119 because command completion also publishes the updated context reading.

Verified with typecheck, lint, 99 tests, direct ACP `/fh-system-prompt`, and cs-mesh `/fh` plus three-step `/fh-model` selection.